### PR TITLE
[FLINK-31063] Prevent duplicate reading when restoring from a checkpoint.

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/MongoSourceReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/MongoSourceReader.java
@@ -24,6 +24,8 @@ import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSource
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplitState;
 import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
 import org.apache.flink.connector.mongodb.source.split.MongoSourceSplitState;
 
@@ -77,7 +79,11 @@ public class MongoSourceReader<OUT>
 
     @Override
     protected MongoSourceSplitState initializedState(MongoSourceSplit split) {
-        return new MongoSourceSplitState(split);
+        if (split instanceof MongoScanSourceSplit) {
+            return new MongoScanSourceSplitState((MongoScanSourceSplit) split);
+        } else {
+            throw new IllegalArgumentException("Unknown split type.");
+        }
     }
 
     @Override

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/emitter/MongoRecordEmitter.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/emitter/MongoRecordEmitter.java
@@ -47,6 +47,8 @@ public class MongoRecordEmitter<T>
     public void emitRecord(
             BsonDocument document, SourceOutput<T> output, MongoSourceSplitState splitState)
             throws Exception {
+        // Update current offset.
+        splitState.updateOffset(document);
         // Sink the record to source output.
         sourceOutputWrapper.setSourceOutput(output);
         deserializationSchema.deserialize(document, sourceOutputWrapper);

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -179,7 +179,7 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
                             .min(currentSplit.getMin())
                             .max(currentSplit.getMax())
                             .hint(currentSplit.getHint())
-                            .sort(currentSplit.getHint())
+                            .sort(currentSplit.getSort())
                             .noCursorTimeout(readOptions.isNoCursorTimeout());
 
             // Current split is partial read and recovered from checkpoint.

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -179,6 +179,7 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
                             .min(currentSplit.getMin())
                             .max(currentSplit.getMax())
                             .hint(currentSplit.getHint())
+                            .sort(currentSplit.getHint())
                             .noCursorTimeout(readOptions.isNoCursorTimeout());
 
             // Current split is partial read and recovered from checkpoint.

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -181,6 +181,11 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
                             .hint(currentSplit.getHint())
                             .noCursorTimeout(readOptions.isNoCursorTimeout());
 
+            // Current split is partial read and recovered from checkpoint.
+            if (currentSplit.getOffset() > 0) {
+                findIterable.skip(currentSplit.getOffset());
+            }
+
             // Push limit down
             if (readerContext.isLimitPushedDown()) {
                 findIterable.limit(readerContext.getLimit());

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -179,7 +179,6 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
                             .min(currentSplit.getMin())
                             .max(currentSplit.getMax())
                             .hint(currentSplit.getHint())
-                            .sort(currentSplit.getSort())
                             .noCursorTimeout(readOptions.isNoCursorTimeout());
 
             // Current split was partially read and recovered from checkpoint

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -182,7 +182,7 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
                             .sort(currentSplit.getSort())
                             .noCursorTimeout(readOptions.isNoCursorTimeout());
 
-            // Current split is partial read and recovered from checkpoint.
+            // Current split was partially read and recovered from checkpoint
             if (currentSplit.getOffset() > 0) {
                 findIterable.skip(currentSplit.getOffset());
             }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 
 import java.util.Objects;
 
@@ -91,6 +92,20 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
 
     public int getOffset() {
         return offset;
+    }
+
+    public BsonDocument getSort() {
+        BsonDocument sort = new BsonDocument();
+        hint.forEach(
+                (k, v) -> {
+                    if (v.isInt32()) {
+                        sort.append(k, v);
+                    } else {
+                        // Normalize order if is a hashed index, eg. { f1: 'hashed' } -> { f1: 1 }
+                        sort.append(k, new BsonInt32(1));
+                    }
+                });
+        return sort;
     }
 
     @Override

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
@@ -40,6 +40,8 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
 
     private final BsonDocument hint;
 
+    private final int offset;
+
     public MongoScanSourceSplit(
             String splitId,
             String database,
@@ -47,12 +49,24 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
             BsonDocument min,
             BsonDocument max,
             BsonDocument hint) {
+        this(splitId, database, collection, min, max, hint, 0);
+    }
+
+    public MongoScanSourceSplit(
+            String splitId,
+            String database,
+            String collection,
+            BsonDocument min,
+            BsonDocument max,
+            BsonDocument hint,
+            int offset) {
         super(splitId);
         this.database = database;
         this.collection = collection;
         this.min = min;
         this.max = max;
         this.hint = hint;
+        this.offset = offset;
     }
 
     public String getDatabase() {
@@ -75,6 +89,10 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
         return hint;
     }
 
+    public int getOffset() {
+        return offset;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -91,11 +109,12 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
                 && Objects.equals(collection, split.collection)
                 && Objects.equals(min, split.min)
                 && Objects.equals(max, split.max)
-                && Objects.equals(hint, split.hint);
+                && Objects.equals(hint, split.hint)
+                && offset == split.offset;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), database, collection, min, max, hint);
+        return Objects.hash(super.hashCode(), database, collection, min, max, hint, offset);
     }
 }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 
 import java.util.Objects;
 
@@ -92,20 +91,6 @@ public class MongoScanSourceSplit extends MongoSourceSplit {
 
     public int getOffset() {
         return offset;
-    }
-
-    public BsonDocument getSort() {
-        BsonDocument sort = new BsonDocument();
-        hint.forEach(
-                (k, v) -> {
-                    if (v.isInt32()) {
-                        sort.append(k, v);
-                    } else {
-                        // Normalize order if is a hashed index, eg. { f1: 'hashed' } -> { f1: 1 }
-                        sort.append(k, new BsonInt32(1));
-                    }
-                });
-        return sort;
     }
 
     @Override

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
@@ -23,18 +23,19 @@ import org.bson.BsonDocument;
 
 /** MongoDB source split state for {@link MongoScanSourceSplit}. */
 @PublicEvolving
-public class MongoScanSourceSplitState extends MongoSourceSplitState {
+public class MongoScanSourceSplitState implements MongoSourceSplitState {
+
+    private final MongoScanSourceSplit scanSplit;
 
     private int offset;
 
     public MongoScanSourceSplitState(MongoScanSourceSplit scanSplit) {
-        super(scanSplit);
+        this.scanSplit = scanSplit;
         this.offset = scanSplit.getOffset();
     }
 
     @Override
     public MongoScanSourceSplit toMongoSourceSplit() {
-        MongoScanSourceSplit scanSplit = (MongoScanSourceSplit) split;
         return new MongoScanSourceSplit(
                 scanSplit.splitId(),
                 scanSplit.getDatabase(),

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.split;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import org.bson.BsonDocument;
+
+/** MongoDB source split state for {@link MongoScanSourceSplit}. */
+@PublicEvolving
+public class MongoScanSourceSplitState extends MongoSourceSplitState {
+
+    private int offset;
+
+    public MongoScanSourceSplitState(MongoScanSourceSplit scanSplit) {
+        super(scanSplit);
+        this.offset = scanSplit.getOffset();
+    }
+
+    @Override
+    public MongoScanSourceSplit toMongoSourceSplit() {
+        MongoScanSourceSplit scanSplit = (MongoScanSourceSplit) split;
+        return new MongoScanSourceSplit(
+                scanSplit.splitId(),
+                scanSplit.getDatabase(),
+                scanSplit.getCollection(),
+                scanSplit.getMin(),
+                scanSplit.getMax(),
+                scanSplit.getHint(),
+                offset);
+    }
+
+    @Override
+    public void updateOffset(BsonDocument record) {
+        offset++;
+    }
+}

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplitState.java
@@ -17,12 +17,12 @@
 
 package org.apache.flink.connector.mongodb.source.split;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
 import org.bson.BsonDocument;
 
 /** MongoDB source split state for {@link MongoScanSourceSplit}. */
-@PublicEvolving
+@Internal
 public class MongoScanSourceSplitState implements MongoSourceSplitState {
 
     private final MongoScanSourceSplit scanSplit;

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitSerializer.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitSerializer.java
@@ -80,6 +80,7 @@ public class MongoSourceSplitSerializer implements SimpleVersionedSerializer<Mon
             out.writeUTF(split.getMin().toJson());
             out.writeUTF(split.getMax().toJson());
             out.writeUTF(split.getHint().toJson());
+            out.writeInt(split.getOffset());
         }
     }
 
@@ -93,7 +94,9 @@ public class MongoSourceSplitSerializer implements SimpleVersionedSerializer<Mon
                 BsonDocument min = BsonDocument.parse(in.readUTF());
                 BsonDocument max = BsonDocument.parse(in.readUTF());
                 BsonDocument hint = BsonDocument.parse(in.readUTF());
-                return new MongoScanSourceSplit(splitId, database, collection, min, max, hint);
+                int offset = in.readInt();
+                return new MongoScanSourceSplit(
+                        splitId, database, collection, min, max, hint, offset);
             default:
                 throw new IOException("Unknown version: " + version);
         }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
@@ -17,12 +17,12 @@
 
 package org.apache.flink.connector.mongodb.source.split;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
 import org.bson.BsonDocument;
 
 /** MongoDB source split state for {@link MongoSourceSplit}. */
-@PublicEvolving
+@Internal
 public interface MongoSourceSplitState {
 
     /** Use the current split state to create a new {@link MongoSourceSplit}. */

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
@@ -19,28 +19,19 @@ package org.apache.flink.connector.mongodb.source.split;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import org.bson.BsonDocument;
+
 /** MongoDB source split state. */
 @PublicEvolving
-public class MongoSourceSplitState {
+public abstract class MongoSourceSplitState {
 
-    private final MongoSourceSplit split;
+    protected final MongoSourceSplit split;
 
     public MongoSourceSplitState(MongoSourceSplit split) {
         this.split = split;
     }
 
-    public MongoSourceSplit toMongoSourceSplit() {
-        if (split instanceof MongoScanSourceSplit) {
-            MongoScanSourceSplit scanSplit = (MongoScanSourceSplit) split;
-            return new MongoScanSourceSplit(
-                    scanSplit.splitId(),
-                    scanSplit.getDatabase(),
-                    scanSplit.getCollection(),
-                    scanSplit.getMin(),
-                    scanSplit.getMax(),
-                    scanSplit.getHint());
-        } else {
-            throw new IllegalStateException("Unknown split type");
-        }
-    }
+    public abstract MongoSourceSplit toMongoSourceSplit();
+
+    public abstract void updateOffset(BsonDocument record);
 }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
@@ -21,17 +21,17 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import org.bson.BsonDocument;
 
-/** MongoDB source split state. */
+/** MongoDB source split state for {@link MongoSourceSplit}. */
 @PublicEvolving
-public abstract class MongoSourceSplitState {
+public interface MongoSourceSplitState {
 
-    protected final MongoSourceSplit split;
+    /** Use the current split state to create a new {@link MongoSourceSplit}. */
+    MongoSourceSplit toMongoSourceSplit();
 
-    public MongoSourceSplitState(MongoSourceSplit split) {
-        this.split = split;
-    }
-
-    public abstract MongoSourceSplit toMongoSourceSplit();
-
-    public abstract void updateOffset(BsonDocument record);
+    /**
+     * Update the offset read by the current split for failure recovery.
+     *
+     * @param record The latest record that was read.
+     */
+    void updateOffset(BsonDocument record);
 }

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
@@ -76,7 +76,6 @@ public class MongoSourceEnumStateSerializerTest {
                 "coll",
                 new BsonDocument("_id", new BsonInt32(index)),
                 new BsonDocument("_id", MongoConstants.BSON_MAX_KEY),
-                ID_HINT,
-                index);
+                ID_HINT);
     }
 }

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
@@ -76,6 +76,7 @@ public class MongoSourceEnumStateSerializerTest {
                 "coll",
                 new BsonDocument("_id", new BsonInt32(index)),
                 new BsonDocument("_id", MongoConstants.BSON_MAX_KEY),
-                ID_HINT);
+                ID_HINT,
+                index);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Exact-once semantics may not be guaranteed at present on partial reads.
We use a number fetchSize to limit the records count for every fetch loop but we didn't record the offset into the split state. When resuming the split reader from a partially completed split, we may re-read some data.

In this PR, we record the current reading offset into split state.
Skip this offset when restoring to prevent duplicate reading.