### PR TITLE
[hotfix] Fix unstable test of MongoSinkITCase.testRecovery

### DIFF
--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/MongoSinkITCase.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/MongoSinkITCase.java
@@ -97,7 +97,7 @@ public class MongoSinkITCase {
     void testWriteToMongoWithDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee)
             throws Exception {
         final String collection = "test-sink-with-delivery-" + deliveryGuarantee;
-        final MongoSink<Document> sink = createSink(collection, deliveryGuarantee);
+        final MongoSink<Document> sink = createSink(collection, deliveryGuarantee, 5, 1000);
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100L);
         env.setRestartStrategy(RestartStrategies.noRestart());
@@ -110,7 +110,8 @@ public class MongoSinkITCase {
     @Test
     void testRecovery() throws Exception {
         final String collection = "test-recovery-mongo-sink";
-        final MongoSink<Document> sink = createSink(collection, DeliveryGuarantee.AT_LEAST_ONCE);
+        final MongoSink<Document> sink =
+                createSink(collection, DeliveryGuarantee.AT_LEAST_ONCE, -1, -1);
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100L);
@@ -128,12 +129,16 @@ public class MongoSinkITCase {
     }
 
     private static MongoSink<Document> createSink(
-            String collection, DeliveryGuarantee deliveryGuarantee) {
+            String collection,
+            DeliveryGuarantee deliveryGuarantee,
+            int batchSize,
+            long batchIntervalMs) {
         return MongoSink.<Document>builder()
                 .setUri(MONGO_CONTAINER.getConnectionString())
                 .setDatabase(TEST_DATABASE)
                 .setCollection(collection)
-                .setBatchSize(5)
+                .setBatchSize(batchSize)
+                .setBatchIntervalMs(batchIntervalMs)
                 .setDeliveryGuarantee(deliveryGuarantee)
                 .setSerializationSchema(new AppendOnlySerializationSchema())
                 .build();


### PR DESCRIPTION
Fix the CI fails https://github.com/apache/flink-connector-mongodb/actions/runs/4435527099/jobs/7782784066.

> 2023-03-16T09:46:59.8097110Z 09:46:52,687 [Source: Sequence Source -> Map -> Map -> Sink: Writer (1/1)#7] ERROR org.apache.flink.connector.mongodb.sink.writer.MongoWriter   [] - Bulk Write to MongoDB failed
2023-03-16T09:46:59.8098540Z com.mongodb.MongoBulkWriteException: Bulk write operation error on server localhost:32771. Write errors: [BulkWriteError{index=0, code=11000, message='E11000 duplicate key error collection: test_sink.test-recovery-mongo-sink index: _id_ dup key: { : 1 }', details={}}]. 

We use non-idempotent writes in this test case and may write some data before checkpointed.
In that case we'll meet duplicate write error.
Set `batchIntervalMs` and `batchSize` to -1 to force writes at checkpoint to make the test stable.

