### PR TITLE
[FLINK-31700][Connectors/MongoDB] Fix MongoDB nightly CI failure

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/DefaultMongoSinkContext.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/DefaultMongoSinkContext.java
@@ -18,15 +18,8 @@
 package org.apache.flink.connector.mongodb.sink.writer.context;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.operators.MailboxExecutor;
-import org.apache.flink.api.common.operators.ProcessingTimeService;
-import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
-import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.util.UserCodeClassLoader;
-
-import java.util.OptionalLong;
 
 /** Default {@link MongoSinkContext} implementation. */
 @Internal
@@ -41,6 +34,11 @@ public class DefaultMongoSinkContext implements MongoSinkContext {
     }
 
     @Override
+    public Sink.InitContext getInitContext() {
+        return initContext;
+    }
+
+    @Override
     public long processTime() {
         return initContext.getProcessingTimeService().getCurrentProcessingTime();
     }
@@ -48,45 +46,5 @@ public class DefaultMongoSinkContext implements MongoSinkContext {
     @Override
     public MongoWriteOptions getWriteOptions() {
         return writeOptions;
-    }
-
-    @Override
-    public UserCodeClassLoader getUserCodeClassLoader() {
-        return initContext.getUserCodeClassLoader();
-    }
-
-    @Override
-    public MailboxExecutor getMailboxExecutor() {
-        return initContext.getMailboxExecutor();
-    }
-
-    @Override
-    public ProcessingTimeService getProcessingTimeService() {
-        return initContext.getProcessingTimeService();
-    }
-
-    @Override
-    public int getSubtaskId() {
-        return initContext.getSubtaskId();
-    }
-
-    @Override
-    public int getNumberOfParallelSubtasks() {
-        return initContext.getNumberOfParallelSubtasks();
-    }
-
-    @Override
-    public SinkWriterMetricGroup metricGroup() {
-        return initContext.metricGroup();
-    }
-
-    @Override
-    public OptionalLong getRestoredCheckpointId() {
-        return initContext.getRestoredCheckpointId();
-    }
-
-    @Override
-    public SerializationSchema.InitializationContext asSerializationSchemaInitializationContext() {
-        return initContext.asSerializationSchemaInitializationContext();
     }
 }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContext.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContext.java
@@ -24,7 +24,10 @@ import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializat
 
 /** This context provides information for {@link MongoSerializationSchema}. */
 @PublicEvolving
-public interface MongoSinkContext extends Sink.InitContext {
+public interface MongoSinkContext {
+
+    /** Returns the current sink's init context. */
+    Sink.InitContext getInitContext();
 
     /** Returns the current process time in flink. */
     long processTime();

--- a/flink-connector-mongodb/src/test/resources/archunit.properties
+++ b/flink-connector-mongodb/src/test/resources/archunit.properties
@@ -29,3 +29,6 @@ freeze.store.default.allowStoreUpdate=true
 #freeze.refreeze=true
 
 freeze.store.default.path=archunit-violations
+
+# TRUE by default since 0.23.0, restore the old behavior by setting the ArchUnit property archRule.failOnEmptyShould=false
+archRule.failOnEmptyShould=false


### PR DESCRIPTION
Fix MongoDB nightly CI failure
https://issues.apache.org/jira/browse/FLINK-31700

> Error:  /home/runner/work/flink-connector-mongodb/flink-connector-mongodb/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/DefaultMongoSinkContext.java:[33,8] org.apache.flink.connector.mongodb.sink.writer.context.DefaultMongoSinkContext is not abstract and does not override abstract method getAttemptNumber() in org.apache.flink.api.connector.sink2.Sink.InitContext

This PR made some changes to make flink-mongodb-connector compatible with both 1.16 and 1.17.

We can build it of flink 1.17 via maven command as follows: 
```shell
mvn clean verify -U -B --no-transfer-progress -Dflink.version=1.17.0 \         
    -DaltDeploymentRepository=validation_repository::default::file:/tmp/flink-validation-deployment \
    -Dscala-2.12 -Darchunit.version=1.0.0
```

The version of archunit.version seems not compatible from flink 1.16(0.22.0) to flink 1.17(1.0.0).
https://newreleases.io/project/github/TNG/ArchUnit/release/v0.23.0
We need to manually specify the version and introduce additional configuration `archRule.failOnEmptyShould=false` to keep compatibility.

