### PR TITLE
[FLINK-32446][Connectors/MongoDB]  MongoWriter should regularly check whether the last write time is over limit

### DIFF
--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriterITCase.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriterITCase.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 
 import static org.apache.flink.connector.mongodb.testutils.MongoTestUtil.assertThatIdsAreNotWritten;
 import static org.apache.flink.connector.mongodb.testutils.MongoTestUtil.assertThatIdsAreWritten;
+import static org.apache.flink.connector.mongodb.testutils.MongoTestUtil.assertThatIdsAreWrittenWithMaxWaitTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -138,12 +139,12 @@ public class MongoWriterITCase {
                 createWriter(collection, batchSize, batchIntervalMs, flushOnCheckpoint)) {
             writer.write(buildMessage(1), null);
             writer.write(buildMessage(2), null);
+            writer.doBulkWrite();
             writer.write(buildMessage(3), null);
             writer.write(buildMessage(4), null);
-            writer.doBulkWrite();
-        }
 
-        assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3, 4);
+            assertThatIdsAreWrittenWithMaxWaitTime(collectionOf(collection), 10000L, 1, 2, 3, 4);
+        }
     }
 
     @Test

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
@@ -77,4 +77,17 @@ public class MongoTestUtil {
 
         assertThat(actualIds).containsExactlyInAnyOrder(ids);
     }
+
+    public static void assertThatIdsAreWrittenWithMaxWaitTime(
+            MongoCollection<Document> coll, long maxWaitTimeMs, Integer... ids)
+            throws InterruptedException {
+        long startTimeMillis = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTimeMillis < maxWaitTimeMs) {
+            if (coll.countDocuments(Filters.in("_id", ids)) == ids.length) {
+                break;
+            }
+            Thread.sleep(1000L);
+        }
+        assertThatIdsAreWritten(coll, ids);
+    }
 }


### PR DESCRIPTION
Mongo sink waits for new record to write previous records. I have a upsert-kafka topic filled that has already some events. I start a new upsert-kafka to mongo db sink job. I expect all the data from the topic to be loaded to mongodb right away. But instead, only the first record is written to mongo db. The rest of the records don’t arrive in mongodb until a new event is written to kafka topic. The new event that was written is delayed until the next event arrives. 

To prevent this problem, the MongoWriter should regularly check whether the last write time is over the specific limit.