### PR TITLE
[FLINK-32348][connectors/mongodb] Fix MongoDB tests are flaky and timeout

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -119,7 +119,6 @@ public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoS
             throw new IOException("Scan records form MongoDB failed", e);
         } finally {
             if (finished) {
-                currentSplit = null;
                 closeCursor();
             }
         }


### PR DESCRIPTION
A full run with thread dumps can be found at https://github.com/apache/flink-connector-mongodb/actions/runs/5276796512/jobs/9543998611?pr=10#step:15:48

The root cause of this error is not removing it from `readersAwaitingSplit` when closing an idle reader.
This resulted in splits being incorrectly assigned to readers that did not complete when resuming tasks from checkpoints.

1. `readersAwaitingSplit`: [0]
2. `signalNoMoreSplits` but not remove 0 from `readersAwaitingSplit`
3.  TaskManager failover
4.  split request from reader 1 -> `readersAwaitingSplit`: [0, 1]
5.  but actually assigns split to reader 0.
