### PR TITLE
[FLINK-32757][connectors/mongodb][build] Update the copyright with year 2023

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink MongoDB Connector
-Copyright 2014-2022 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-mongodb
-Copyright 2014-2022 The Apache Software Foundation
+Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
The current copyright year is 2014-2022 in NOTICE files. 
We should change it to 2014-2023.