### PR TITLE
[FLINK-33380][connectors/mongodb] Bump Flink version to include 1.18 and 1.19-SNAPSHOT

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT, 1.19-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -36,13 +36,19 @@ jobs:
           flink: 1.18-SNAPSHOT,
           branch: main
         }, {
+          flink: 1.19-SNAPSHOT,
+          branch: main
+        }, {
           flink: 1.16.2,
           branch: v1.0
         }, {
           flink: 1.17.1,
           branch: v1.0
+        },{
+          flink: 1.18.0,
+          branch: v1.0
         }, {
-          flink: 1.18-SNAPSHOT,
+          flink: 1.19-SNAPSHOT,
           branch: v1.0
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,20 @@ under the License.
 				<scope>test</scope>
 			</dependency>
 
+			<!-- For dependency convergence  -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.24.0</version>
+			</dependency>
+
+			<!-- For dependency convergence  -->
+			<dependency>
+				<groupId>org.xerial.snappy</groupId>
+				<artifactId>snappy-java</artifactId>
+				<version>1.1.10.4</version>
+			</dependency>
+			
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>com.esotericsoftware.kryo</groupId>


### PR DESCRIPTION
Backport of https://github.com/apache/flink-connector-mongodb/pull/18