### PR TITLE
[hotfix] Test connector against Flink 1.16.2, 1.17.1, 1.18.0 instead of Flink SNAPSHOT version

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT, 1.19-SNAPSHOT]
+        flink: [1.16.2, 1.17.1, 1.18.0, 1.19-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,13 +27,13 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.16-SNAPSHOT,
+          flink: 1.16.2,
           branch: main
         }, {
-          flink: 1.17-SNAPSHOT,
+          flink: 1.17.1,
           branch: main
         }, {
-          flink: 1.18-SNAPSHOT,
+          flink: 1.18.0,
           branch: main
         }, {
           flink: 1.19-SNAPSHOT,


### PR DESCRIPTION
This PR change the ci to use the release version 1.16.2, 1.17.1, 1.18.0 instead of Flink SNAPSHOT version.