### PR TITLE
[FLINK-33899][connectors/mongodb] Java 17 and 21 support for mongodb connector

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,14 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT, 1.19-SNAPSHOT]
+        flink: [ 1.16-SNAPSHOT, 1.17-SNAPSHOT ]
+        jdk: [ '8, 11' ]
+        include:
+          - flink: 1.18-SNAPSHOT
+            jdk: '8, 11, 17'
+          - flink: 1.19-SNAPSHOT
+            jdk: '8, 11, 17, 21'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -34,25 +34,26 @@ jobs:
           branch: main
         }, {
           flink: 1.18-SNAPSHOT,
+          jdk: '8, 11, 17',
           branch: main
         }, {
           flink: 1.19-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
           branch: main
         }, {
           flink: 1.16.2,
-          branch: v1.0
+          branch: v3.1
         }, {
           flink: 1.17.1,
-          branch: v1.0
-        },{
-          flink: 1.18.0,
-          branch: v1.0
+          branch: v3.1
         }, {
-          flink: 1.19-SNAPSHOT,
-          branch: v1.0
+          flink: 1.18.0,
+          jdk: '8, 11, 17',
+          branch: v3.1
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
+      jdk_version: ${{ matrix.flink_branches.jdk || '8, 11' }}
       run_dependency_convergence: false

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -41,15 +41,15 @@ jobs:
           jdk: '8, 11, 17, 21',
           branch: main
         }, {
-          flink: 1.16.2,
-          branch: v3.1
+          flink: 1.16.3,
+          branch: v1.0
         }, {
-          flink: 1.17.1,
-          branch: v3.1
+          flink: 1.17.2,
+          branch: v1.0
         }, {
-          flink: 1.18.0,
+          flink: 1.18.1,
           jdk: '8, 11, 17',
-          branch: v3.1
+          branch: v1.0
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/flink-connector-mongodb/pom.xml
+++ b/flink-connector-mongodb/pom.xml
@@ -32,6 +32,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config>
+			--add-opens=java.base/java.util=ALL-UNNAMED
+			--add-opens=java.base/java.lang=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<!-- Core -->
 

--- a/flink-connector-mongodb/pom.xml
+++ b/flink-connector-mongodb/pom.xml
@@ -34,7 +34,9 @@ under the License.
 
 	<properties>
 		<surefire.module.config>
+			<!-- required by MongoSinkITCase, MongoSourceITCase -->
 			--add-opens=java.base/java.util=ALL-UNNAMED
+			<!-- required by MongoDynamicTableSourceITCase, MongoDynamicTableSinkITCase -->
 			--add-opens=java.base/java.lang=ALL-UNNAMED
 		</surefire.module.config>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@ under the License.
 		<log4j.version>2.17.2</log4j.version>
 
 		<flink.parent.artifactId>flink-connector-mongodb-parent</flink.parent.artifactId>
+		<!-- These 2 properties should be removed together with upgrade of flink-connector-parent to 1.1.x -->
+		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
+		<surefire.module.config/>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
After [FLINK-33302](https://issues.apache.org/jira/browse/FLINK-33302) is finished it is now possible to specify jdk version
That allows to add jdk17 and jdk21 support.