### PR TITLE
[FLINK-34216][connectors/mongodb] FLIP-377: Support fine-grained configuration to control filter push down for MongoDB Connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/mongodb.md
+++ b/docs/content.zh/docs/connectors/table/mongodb.md
@@ -232,6 +232,19 @@ ON myTopic.key = MyUserTable._id;
       <td>查询数据库失败的最大重试时间。</td>
     </tr>
     <tr>
+      <td><h5>filter.handling.policy</h5></td>
+      <td>可选</td>
+      <td>否</td>
+      <td style="word-wrap: break-word;">always</td>
+      <td>枚举值，可选项: always, never</td>
+      <td>过滤器下推策略，支持的策略有:
+          <ul>
+            <li><code>always</code>: 始终将支持的过滤器下推到数据库.</li>
+            <li><code>never</code>: 不将任何过滤器下推到数据库.</li>
+          </ul>
+      </td>
+    </tr>
+    <tr>
       <td><h5>sink.buffer-flush.max-rows</h5></td>
       <td>可选</td>
       <td>是</td>

--- a/docs/content/docs/connectors/table/mongodb.md
+++ b/docs/content/docs/connectors/table/mongodb.md
@@ -237,6 +237,20 @@ Connector Options
       <td>Specifies the retry time interval if lookup records from database failed.</td>
     </tr>
     <tr>
+      <td><h5>filter.handling.policy</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">always</td>
+      <td>Enum Possible values: always, never</td>
+      <td>Fine-grained configuration to control filter push down. 
+          Supported policies are:
+          <ul>
+            <li><code>always</code>: Always push the supported filters to MongoDB.</li>
+            <li><code>never</code>: Never push any filters to MongoDB.</li>
+          </ul>
+      </td>
+    </tr>
+    <tr>
       <td><h5>sink.buffer-flush.max-rows</h5></td>
       <td>optional</td>
       <td>yes</td>

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/FilterHandlingPolicy.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/FilterHandlingPolicy.java
@@ -1,0 +1,33 @@
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
+
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/** Fine-grained configuration to control filter push down for MongoDB Table/SQL source. */
+@PublicEvolving
+public enum FilterHandlingPolicy implements DescribedEnum {
+    ALWAYS("always", text("Always push the supported filters to MongoDB.")),
+
+    NEVER("never", text("Never push any filters to MongoDB."));
+
+    private final String name;
+    private final InlineElement description;
+
+    FilterHandlingPolicy(String name, InlineElement description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public InlineElement getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
@@ -139,4 +139,11 @@ public class MongoConnectorOptions {
                     .defaultValue(Duration.ofMillis(1000L))
                     .withDescription(
                             "Specifies the retry time interval if writing records to database failed.");
+
+    public static final ConfigOption<FilterHandlingPolicy> FILTER_HANDLING_POLICY =
+            ConfigOptions.key("filter.handling.policy")
+                    .enumType(FilterHandlingPolicy.class)
+                    .defaultValue(FilterHandlingPolicy.ALWAYS)
+                    .withDescription(
+                            "Fine-grained configuration to control filter push down for MongoDB Table/SQL source.");
 }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
@@ -43,6 +43,7 @@ import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.BUF
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.COLLECTION;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DATABASE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DELIVERY_GUARANTEE;
+import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.FILTER_HANDLING_POLICY;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.LOOKUP_RETRY_INTERVAL;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_FETCH_SIZE;
@@ -99,6 +100,7 @@ public class MongoDynamicTableFactory
         optionalOptions.add(LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_WRITE);
         optionalOptions.add(LookupOptions.PARTIAL_CACHE_MAX_ROWS);
         optionalOptions.add(LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY);
+        optionalOptions.add(FILTER_HANDLING_POLICY);
         return optionalOptions;
     }
 
@@ -132,6 +134,7 @@ public class MongoDynamicTableFactory
                 getLookupCache(options),
                 config.getLookupMaxRetries(),
                 config.getLookupRetryIntervalMs(),
+                config.getFilterHandlingPolicy(),
                 context.getPhysicalRowDataType());
     }
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+import org.apache.flink.connector.mongodb.table.FilterHandlingPolicy;
 import org.apache.flink.table.connector.source.lookup.LookupOptions;
 
 import javax.annotation.Nullable;
@@ -33,6 +34,7 @@ import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.BUF
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.COLLECTION;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DATABASE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DELIVERY_GUARANTEE;
+import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.FILTER_HANDLING_POLICY;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.LOOKUP_RETRY_INTERVAL;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_FETCH_SIZE;
@@ -95,6 +97,10 @@ public class MongoConfiguration {
 
     public long getLookupRetryIntervalMs() {
         return config.get(LOOKUP_RETRY_INTERVAL).toMillis();
+    }
+
+    public FilterHandlingPolicy getFilterHandlingPolicy() {
+        return config.get(FILTER_HANDLING_POLICY);
     }
 
     // -----------------------------------Write Config------------------------------------------

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
@@ -46,6 +46,7 @@ import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.BUF
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.COLLECTION;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DATABASE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DELIVERY_GUARANTEE;
+import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.FILTER_HANDLING_POLICY;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.LOOKUP_RETRY_INTERVAL;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_FETCH_SIZE;
@@ -89,6 +90,7 @@ public class MongoDynamicTableFactoryTest {
                         null,
                         LookupOptions.MAX_RETRIES.defaultValue(),
                         LOOKUP_RETRY_INTERVAL.defaultValue().toMillis(),
+                        FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
         assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -115,6 +117,7 @@ public class MongoDynamicTableFactoryTest {
         properties.put(SCAN_PARTITION_STRATEGY.key(), "split-vector");
         properties.put(SCAN_PARTITION_SIZE.key(), "128m");
         properties.put(SCAN_PARTITION_SAMPLES.key(), "5");
+        properties.put(FILTER_HANDLING_POLICY.key(), "never");
 
         DynamicTableSource actual = createTableSource(SCHEMA, properties);
 
@@ -135,6 +138,7 @@ public class MongoDynamicTableFactoryTest {
                         null,
                         LookupOptions.MAX_RETRIES.defaultValue(),
                         LOOKUP_RETRY_INTERVAL.defaultValue().toMillis(),
+                        FilterHandlingPolicy.NEVER,
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);
@@ -162,6 +166,7 @@ public class MongoDynamicTableFactoryTest {
                         DefaultLookupCache.fromConfig(Configuration.fromMap(properties)),
                         10,
                         20,
+                        FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSourceITCase.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSourceITCase.java
@@ -81,6 +81,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.COLLECTION;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.DATABASE;
+import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.FILTER_HANDLING_POLICY;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.URI;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -241,9 +242,13 @@ class MongoDynamicTableSourceITCase {
         }
     }
 
-    @Test
-    void testFilter() {
-        tEnv.executeSql(createTestDDl(null));
+    @ParameterizedTest
+    @EnumSource(FilterHandlingPolicy.class)
+    void testFilter(FilterHandlingPolicy filterHandlingPolicy) {
+        tEnv.executeSql(
+                createTestDDl(
+                        Collections.singletonMap(
+                                FILTER_HANDLING_POLICY.key(), filterHandlingPolicy.name())));
 
         // we create a VIEW here to test column remapping, i.e. would filter push down work if we
         // create a view that depends on our source table

--- a/flink-connector-mongodb/src/test/resources/org/apache/flink/connector/mongodb/table/MongoTablePlanTest.xml
+++ b/flink-connector-mongodb/src/test/resources/org/apache/flink/connector/mongodb/table/MongoTablePlanTest.xml
@@ -69,4 +69,22 @@ Calc(select=[id, timestamp3_col, int_col], where=[(id IS NOT NULL OR (double_col
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNeverFilterPushdown">
+    <Resource name="sql">
+      <![CDATA[SELECT id, timestamp3_col, int_col FROM mongo WHERE id = 900001 AND decimal_col > 1.0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], timestamp3_col=[$4], int_col=[$5])
++- LogicalFilter(condition=[AND(=($0, 900001), >($7, 1.0:DECIMAL(2, 1)))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, mongo]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[CAST(900001 AS BIGINT) AS id, timestamp3_col, int_col], where=[((id = 900001) AND (decimal_col > 1.0))])
++- TableSourceScan(table=[[default_catalog, default_database, mongo, filter=[], project=[id, timestamp3_col, int_col, decimal_col]]], fields=[id, timestamp3_col, int_col, decimal_col])
+]]>
+    </Resource>
+  </TestCase>
 </Root>


### PR DESCRIPTION
[FLINK-34216][connectors/mongodb] FLIP-377: Support fine-grained configuration to control filter push down for MongoDB Connector


This improvement implements [FLIP-377 Support fine-grained configuration to control filter push down for Table/SQL Sources](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=276105768)

This FLIP has 2 goals:

- Introduces a new configuration filter.handling.policy to the JDBC and MongoDB connector.
- Suggests a convention option name if other connectors are going to add an option for the same purpose.