### PR TITLE
[FLINK-34958] Add support Flink 1.20-SNAPSHOT and bump flink-connector-parent to 1.1.0 for mongodb connector

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -32,6 +32,8 @@ jobs:
             jdk: '8, 11, 17'
           - flink: 1.19-SNAPSHOT
             jdk: '8, 11, 17, 21'
+          - flink: 1.20-SNAPSHOT
+            jdk: '8, 11, 17, 21'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,11 +38,19 @@ jobs:
           jdk: '8, 11, 17, 21',
           branch: main
         }, {
+          flink: 1.20-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
+          branch: main
+        }, {
           flink: 1.17.2,
           branch: v1.1
         }, {
           flink: 1.18.1,
           jdk: '8, 11, 17',
+          branch: v1.1
+        }, {
+          flink: 1.19.0,
+          jdk: '8, 11, 17, 21',
           branch: v1.1
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@ under the License.
 		<!-- These 2 properties should be removed together with upgrade of flink-connector-parent to 1.1.x -->
 		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
 		<surefire.module.config/>
+		<spotless.skip>false</spotless.skip>
 	</properties>
 
 	<modules>
@@ -371,6 +372,9 @@ under the License.
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
+				<configuration>
+					<skip>${spotless.skip}</skip>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -398,4 +402,20 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>java21</id>
+			<activation>
+				<jdk>[21,)</jdk>
+			</activation>
+			<properties>
+				<!-- Current google format does not run on Java 21.
+					 Don't upgrade it in this profile because it formats code differently.
+					 Re-evaluate once support for Java 8 is dropped. -->
+				<spotless.skip>true</spotless.skip>
+			</properties>
+		</profile>
+	</profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.1.0</version>
 	</parent>
 
 	<groupId>org.apache.flink</groupId>
@@ -59,7 +59,6 @@ under the License.
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
-		<mockito.version>3.4.6</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>
@@ -107,20 +106,6 @@ under the License.
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
-			<type>jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 
@@ -263,22 +248,6 @@ under the License.
 				<version>${junit5.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.mockito</groupId>
-				<artifactId>mockito-inline</artifactId>
-				<version>${mockito.version}</version>
-				<type>jar</type>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.mockito</groupId>
-				<artifactId>mockito-core</artifactId>
-				<version>${mockito.version}</version>
-				<type>jar</type>
-				<scope>test</scope>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
- Add CI support for Flink 1.20-SNAPSHOT.
- Bump flink-connector-parent to 1.1.0 for mongodb connector.