### PR TITLE
[FLINK-35010][connectors/mongodb] Bump org.apache.commons:commons-compress from 1.24.0 to 1.26.1 for Flink Mongodb connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@ under the License.
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
+		<commons-compress.version>1.26.1</commons-compress.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>
@@ -261,7 +262,21 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.24.0</version>
+				<version>${commons-compress.version}</version>
+			</dependency>
+
+			<!-- For dependency convergence  -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.14.0</version>
+			</dependency>
+
+			<!-- For dependency convergence  -->
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.15.1</version>
 			</dependency>
 
 			<!-- For dependency convergence  -->


### PR DESCRIPTION
Changes:

-  Bump org.apache.commons:commons-compress from 1.24.0 to 1.26.0 for Flink Mongodb connector