### PR TITLE
[FLINK-35623] Bump mongo-driver version from 4.7.2 to 5.1.1 to support MongoDB 7.0

### DIFF
--- a/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.mongodb:bson:4.7.2
-- org.mongodb:mongodb-driver-core:4.7.2
-- org.mongodb:mongodb-driver-sync:4.7.2
+- org.mongodb:bson:5.1.1
+- org.mongodb:mongodb-driver-core:5.1.1
+- org.mongodb:mongodb-driver-sync:5.1.1

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
 	</scm>
 
 	<properties>
-		<mongodb.version>4.7.2</mongodb.version>
+		<mongodb.version>5.1.1</mongodb.version>
 
 		<flink.version>1.18.0</flink.version>
 		<scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
Bump mongo-driver version from 4.7.2 to 5.1.1 to support MongoDB 7.0

https://www.mongodb.com/docs/drivers/java/sync/current/compatibility/