### PR TITLE
[FLINK-35616][Connectors/MongoDB] Support upsert into sharded collections

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoValidationUtils.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoValidationUtils.java
@@ -18,7 +18,7 @@
 package org.apache.flink.connector.mongodb.common.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.connector.mongodb.table.MongoKeyExtractor;
+import org.apache.flink.connector.mongodb.table.MongoPrimaryKeyExtractor;
 import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
@@ -93,7 +93,7 @@ public class MongoValidationUtils {
      *   <li>Starting in version 4.2, MongoDB removes the Index Key Limit.
      * </ul>
      *
-     * <p>As of now it is extracted by {@link MongoKeyExtractor} according to the primary key
+     * <p>As of now it is extracted by {@link MongoPrimaryKeyExtractor} according to the primary key
      * specified by the Flink table schema.
      *
      * <ul>

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
@@ -24,19 +24,14 @@ import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
 import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
 import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
 import org.apache.flink.connector.mongodb.table.config.MongoConfiguration;
-import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.lookup.LookupOptions;
 import org.apache.flink.table.connector.source.lookup.cache.DefaultLookupCache;
 import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.util.function.SerializableFunction;
-
-import org.bson.BsonValue;
 
 import javax.annotation.Nullable;
 
@@ -148,18 +143,12 @@ public class MongoDynamicTableFactory
         MongoConfiguration config = new MongoConfiguration(helper.getOptions());
         helper.validate();
 
-        ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
-        boolean isUpsert = schema.getPrimaryKey().isPresent();
-        SerializableFunction<RowData, BsonValue> keyExtractor =
-                MongoKeyExtractor.createKeyExtractor(schema);
-
         return new MongoDynamicTableSink(
                 getConnectionOptions(config),
                 getWriteOptions(config),
                 config.getSinkParallelism(),
-                isUpsert,
-                context.getPhysicalRowDataType(),
-                keyExtractor);
+                context.getCatalogTable().getResolvedSchema(),
+                context.getCatalogTable().getPartitionKeys().toArray(new String[0]));
     }
 
     @Nullable

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSink.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSink.java
@@ -24,46 +24,58 @@ import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
 import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
 import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters.RowDataToBsonConverter;
 import org.apache.flink.connector.mongodb.table.serialization.MongoRowDataSerializationSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.function.SerializableFunction;
 
+import org.bson.BsonDocument;
 import org.bson.BsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A {@link DynamicTableSink} for MongoDB. */
 @Internal
-public class MongoDynamicTableSink implements DynamicTableSink {
+public class MongoDynamicTableSink implements DynamicTableSink, SupportsPartitioning {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDynamicTableSink.class);
 
     private final MongoConnectionOptions connectionOptions;
     private final MongoWriteOptions writeOptions;
     @Nullable private final Integer parallelism;
     private final boolean isUpsert;
-    private final DataType physicalRowDataType;
+    private final ResolvedSchema resolvedSchema;
+    private final String[] partitionKeys;
     private final SerializableFunction<RowData, BsonValue> keyExtractor;
+    private final SerializableFunction<RowData, BsonDocument> shardKeysExtractor;
 
     public MongoDynamicTableSink(
             MongoConnectionOptions connectionOptions,
             MongoWriteOptions writeOptions,
             @Nullable Integer parallelism,
-            boolean isUpsert,
-            DataType physicalRowDataType,
-            SerializableFunction<RowData, BsonValue> keyExtractor) {
+            ResolvedSchema resolvedSchema,
+            String[] partitionKeys) {
         this.connectionOptions = checkNotNull(connectionOptions);
         this.writeOptions = checkNotNull(writeOptions);
         this.parallelism = parallelism;
-        this.isUpsert = isUpsert;
-        this.physicalRowDataType = checkNotNull(physicalRowDataType);
-        this.keyExtractor = checkNotNull(keyExtractor);
+        this.resolvedSchema = checkNotNull(resolvedSchema);
+        this.partitionKeys = checkNotNull(partitionKeys);
+        this.isUpsert = resolvedSchema.getPrimaryKey().isPresent();
+        this.keyExtractor = MongoKeyExtractor.createKeyExtractor(resolvedSchema);
+        this.shardKeysExtractor =
+                MongoShardKeysExtractor.createShardKeyExtractor(resolvedSchema, partitionKeys);
     }
 
     @Override
@@ -79,10 +91,11 @@ public class MongoDynamicTableSink implements DynamicTableSink {
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         final RowDataToBsonConverter rowDataToBsonConverter =
                 RowDataToBsonConverters.createConverter(
-                        (RowType) physicalRowDataType.getLogicalType());
+                        (RowType) resolvedSchema.toPhysicalRowDataType().getLogicalType());
 
         final MongoRowDataSerializationSchema serializationSchema =
-                new MongoRowDataSerializationSchema(rowDataToBsonConverter, keyExtractor);
+                new MongoRowDataSerializationSchema(
+                        rowDataToBsonConverter, keyExtractor, shardKeysExtractor);
 
         final MongoSink<RowData> mongoSink =
                 MongoSink.<RowData>builder()
@@ -100,14 +113,15 @@ public class MongoDynamicTableSink implements DynamicTableSink {
     }
 
     @Override
+    public void applyStaticPartition(Map<String, String> partition) {
+        // The value of the partition keys is obtained at runtime, just print static partition here.
+        LOG.info("Applied static partition: {}", partition);
+    }
+
+    @Override
     public MongoDynamicTableSink copy() {
         return new MongoDynamicTableSink(
-                connectionOptions,
-                writeOptions,
-                parallelism,
-                isUpsert,
-                physicalRowDataType,
-                keyExtractor);
+                connectionOptions, writeOptions, parallelism, resolvedSchema, partitionKeys);
     }
 
     @Override
@@ -128,12 +142,19 @@ public class MongoDynamicTableSink implements DynamicTableSink {
                 && Objects.equals(writeOptions, that.writeOptions)
                 && Objects.equals(parallelism, that.parallelism)
                 && Objects.equals(isUpsert, that.isUpsert)
-                && Objects.equals(physicalRowDataType, that.physicalRowDataType);
+                && Objects.equals(resolvedSchema, that.resolvedSchema)
+                && Arrays.equals(partitionKeys, that.partitionKeys);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                connectionOptions, writeOptions, parallelism, isUpsert, physicalRowDataType);
+        return 31
+                        * Objects.hash(
+                                connectionOptions,
+                                writeOptions,
+                                parallelism,
+                                isUpsert,
+                                resolvedSchema)
+                + Arrays.hashCode(partitionKeys);
     }
 }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractor.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractor.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** An extractor for a MongoDB key from a {@link RowData}. */
+/** An extractor for a MongoDB primary key from a {@link RowData}. */
 @Internal
 public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValue> {
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoPrimaryKeyExtractor.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoPrimaryKeyExtractor.java
@@ -42,14 +42,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** An extractor for a MongoDB primary key from a {@link RowData}. */
 @Internal
-public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValue> {
+public class MongoPrimaryKeyExtractor implements SerializableFunction<RowData, BsonValue> {
 
     private static final long serialVersionUID = 1L;
 
     public static final String RESERVED_ID = ID_FIELD;
 
-    private static final AppendOnlyKeyExtractor APPEND_ONLY_KEY_EXTRACTOR =
-            new AppendOnlyKeyExtractor();
+    private static final AppendOnlyPrimaryKeyExtractor APPEND_ONLY_KEY_EXTRACTOR =
+            new AppendOnlyPrimaryKeyExtractor();
 
     private final int[] primaryKeyIndexes;
 
@@ -57,7 +57,7 @@ public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValu
 
     private final FieldGetter primaryKeyGetter;
 
-    private MongoKeyExtractor(LogicalType primaryKeyType, int[] primaryKeyIndexes) {
+    private MongoPrimaryKeyExtractor(LogicalType primaryKeyType, int[] primaryKeyIndexes) {
         this.primaryKeyIndexes = primaryKeyIndexes;
         this.primaryKeyConverter = RowDataToBsonConverters.createFieldDataConverter(primaryKeyType);
 
@@ -85,7 +85,7 @@ public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValu
         return keyValue;
     }
 
-    public static SerializableFunction<RowData, BsonValue> createKeyExtractor(
+    public static SerializableFunction<RowData, BsonValue> createPrimaryKeyExtractor(
             ResolvedSchema resolvedSchema) {
 
         Optional<UniqueConstraint> primaryKey = resolvedSchema.getPrimaryKey();
@@ -125,7 +125,7 @@ public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValu
 
         MongoValidationUtils.validatePrimaryKey(primaryKeyType);
 
-        return new MongoKeyExtractor(primaryKeyType.getLogicalType(), primaryKeyIndexes);
+        return new MongoPrimaryKeyExtractor(primaryKeyType.getLogicalType(), primaryKeyIndexes);
     }
 
     private static boolean isCompoundPrimaryKey(int[] primaryKeyIndexes) {
@@ -141,7 +141,7 @@ public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValu
      * use static class instead of lambda because the maven shade plugin cannot relocate classes in
      * SerializedLambdas (MSHADE-260).
      */
-    private static class AppendOnlyKeyExtractor
+    private static class AppendOnlyPrimaryKeyExtractor
             implements SerializableFunction<RowData, BsonValue> {
         private static final long serialVersionUID = 1L;
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
@@ -81,7 +81,7 @@ public class MongoShardKeysExtractor implements SerializableFunction<RowData, Bs
         return shardKeysDoc;
     }
 
-    public static SerializableFunction<RowData, BsonDocument> createShardKeyExtractor(
+    public static SerializableFunction<RowData, BsonDocument> createShardKeysExtractor(
             ResolvedSchema resolvedSchema, String[] shardKeys) {
         // no shard keys are declared.
         if (shardKeys.length == 0) {

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
@@ -62,7 +62,7 @@ public class MongoShardKeysExtractor implements SerializableFunction<RowData, Bs
     public BsonDocument apply(RowData rowData) {
         BsonDocument shardKeysDoc =
                 Optional.ofNullable(shardKeysGetter.getFieldOrNull(rowData))
-                        .map(shardKeys -> (BsonDocument) shardKeysConverter.apply(shardKeys))
+                        .map(shardKeys -> shardKeysConverter.apply(shardKeys).asDocument())
                         .orElse(EMPTY_DOCUMENT);
 
         shardKeysDoc

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractor.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.function.SerializableFunction;
+
+import org.bson.BsonDocument;
+import org.bson.BsonObjectId;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/** An extractor for a MongoDB shard keys from a {@link RowData}. */
+@Internal
+public class MongoShardKeysExtractor implements SerializableFunction<RowData, BsonDocument> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoShardKeysExtractor.class);
+
+    private static final BsonDocument EMPTY_DOCUMENT = new BsonDocument();
+
+    private final SerializableFunction<Object, BsonValue> shardKeysConverter;
+
+    private final RowData.FieldGetter shardKeysGetter;
+
+    private MongoShardKeysExtractor(LogicalType shardKeysType, int[] shardKeysIndexes) {
+        this.shardKeysConverter = RowDataToBsonConverters.createFieldDataConverter(shardKeysType);
+        this.shardKeysGetter =
+                rowData -> ProjectedRowData.from(shardKeysIndexes).replaceRow(rowData);
+    }
+
+    @Override
+    public BsonDocument apply(RowData rowData) {
+        BsonDocument shardKeysDoc =
+                Optional.ofNullable(shardKeysGetter.getFieldOrNull(rowData))
+                        .map(shardKeys -> (BsonDocument) shardKeysConverter.apply(shardKeys))
+                        .orElse(EMPTY_DOCUMENT);
+
+        shardKeysDoc
+                .entrySet()
+                .forEach(
+                        entry -> {
+                            if (entry.getValue().isString()) {
+                                String keyString = entry.getValue().asString().getValue();
+                                // Try to restore MongoDB's ObjectId from string.
+                                if (ObjectId.isValid(keyString)) {
+                                    entry.setValue(new BsonObjectId(new ObjectId(keyString)));
+                                }
+                            }
+                        });
+
+        return shardKeysDoc;
+    }
+
+    public static SerializableFunction<RowData, BsonDocument> createShardKeyExtractor(
+            ResolvedSchema resolvedSchema, String[] shardKeys) {
+        // no shard keys are declared.
+        if (shardKeys.length == 0) {
+            return new NoOpShardKeysExtractor();
+        }
+
+        int[] shardKeysIndexes = getShardKeysIndexes(resolvedSchema.getColumnNames(), shardKeys);
+        DataType physicalRowDataType = resolvedSchema.toPhysicalRowDataType();
+        DataType shardKeysType = Projection.of(shardKeysIndexes).project(physicalRowDataType);
+
+        MongoShardKeysExtractor shardKeysExtractor =
+                new MongoShardKeysExtractor(shardKeysType.getLogicalType(), shardKeysIndexes);
+
+        LOG.info("Shard keys extractor created, shard keys: {}", Arrays.toString(shardKeys));
+        return shardKeysExtractor;
+    }
+
+    private static int[] getShardKeysIndexes(List<String> columnNames, String[] shardKeys) {
+        return Arrays.stream(shardKeys).mapToInt(columnNames::indexOf).toArray();
+    }
+
+    /**
+     * It behaves as no-op extractor when no shard keys are declared. We use static class instead of
+     * lambda because the maven shade plugin cannot relocate classes in SerializedLambdas
+     * (MSHADE-260).
+     */
+    private static class NoOpShardKeysExtractor
+            implements SerializableFunction<RowData, BsonDocument> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public BsonDocument apply(RowData rowData) {
+            return EMPTY_DOCUMENT;
+        }
+    }
+}

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
@@ -102,9 +102,8 @@ public class MongoDynamicTableFactoryTest {
                         getConnectionOptions(),
                         MongoWriteOptions.builder().build(),
                         null,
-                        SCHEMA.getPrimaryKey().isPresent(),
-                        SCHEMA.toPhysicalRowDataType(),
-                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+                        SCHEMA,
+                        new String[0]);
         assertThat(actualSink).isEqualTo(expectedSink);
     }
 
@@ -191,12 +190,7 @@ public class MongoDynamicTableFactoryTest {
 
         MongoDynamicTableSink expected =
                 new MongoDynamicTableSink(
-                        connectionOptions,
-                        writeOptions,
-                        null,
-                        SCHEMA.getPrimaryKey().isPresent(),
-                        SCHEMA.toPhysicalRowDataType(),
-                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+                        connectionOptions, writeOptions, null, SCHEMA, new String[0]);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -214,12 +208,7 @@ public class MongoDynamicTableFactoryTest {
 
         MongoDynamicTableSink expected =
                 new MongoDynamicTableSink(
-                        connectionOptions,
-                        writeOptions,
-                        2,
-                        SCHEMA.getPrimaryKey().isPresent(),
-                        SCHEMA.toPhysicalRowDataType(),
-                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+                        connectionOptions, writeOptions, 2, SCHEMA, new String[0]);
 
         assertThat(actual).isEqualTo(expected);
     }

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPartitionedTableSinkITCase.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPartitionedTableSinkITCase.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.connector.mongodb.testutils.MongoShardedContainers;
+import org.apache.flink.connector.mongodb.testutils.MongoTestUtil;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.testutils.MongoTestUtil.getConnectorSql;
+import static org.apache.flink.table.api.Expressions.nullOf;
+import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MongoPartitionedTableSinkITCase {
+
+    @RegisterExtension
+    static final MongoShardedContainers MONGO_SHARDED_CONTAINER =
+            MongoTestUtil.createMongoDBShardedContainers(Network.newNetwork());
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .build());
+
+    private MongoClient mongoClient;
+
+    @BeforeEach
+    void setUp() {
+        mongoClient = MongoClients.create(MONGO_SHARDED_CONTAINER.getConnectionString());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    void testSinkIntoPartitionedTable() throws Exception {
+        String database = "test";
+        String collection = "sink_into_sharded_collection";
+
+        // sink into sharded collection by unique index { b: 1, c: 1 }.
+        Bson hashedIndex = BsonDocument.parse("{ b: 1, c: 1 }");
+        MongoTestUtil.createIndex(
+                mongoClient, database, collection, hashedIndex, new IndexOptions().unique(true));
+        MongoTestUtil.shardCollection(mongoClient, database, collection, hashedIndex);
+
+        List<Expression> testValues =
+                Arrays.asList(
+                        row(1L, nullOf(DataTypes.BOOLEAN()), "ABCDEF", 12.12d, 4),
+                        row(1L, nullOf(DataTypes.BOOLEAN()), "ABCDEF", 12.123d, 5));
+        List<String> primaryKeys = Collections.singletonList("a");
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        createPartitionedTable(tEnv, database, collection, primaryKeys, Arrays.asList("b", "c"));
+
+        tEnv.fromValues(testValues).executeInsert("mongo_sink").await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document expected = new Document();
+        expected.put("_id", 1L);
+        expected.put("a", 1L);
+        expected.put("b", null);
+        expected.put("c", "ABCDEF");
+        expected.put("d", 12.123d);
+        expected.put("e", 5);
+
+        assertThat(coll.find(Filters.eq("_id", 1L))).containsExactly(expected);
+    }
+
+    @Test
+    void testSinkIntoPartitionedTableWithMutableShardKey() {
+        String database = "test";
+        String collection = "sink_into_mutable_sharded_collection";
+
+        // sink into sharded collection by unique index { b: 1, c: 1 }.
+        Bson hashedIndex = BsonDocument.parse("{ b: 1, c: 1 }");
+        MongoTestUtil.createIndex(
+                mongoClient, database, collection, hashedIndex, new IndexOptions().unique(true));
+        MongoTestUtil.shardCollection(mongoClient, database, collection, hashedIndex);
+
+        List<Expression> testValues =
+                Arrays.asList(
+                        row(1L, false, "ABCDEF", 12.12d, 4), row(1L, true, "ABCDEF", 12.123d, 5));
+        List<String> primaryKeys = Collections.singletonList("a");
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        createPartitionedTable(tEnv, database, collection, primaryKeys, Arrays.asList("b", "c"));
+
+        // update the shard key value should be failed.
+        assertThatThrownBy(() -> tEnv.fromValues(testValues).executeInsert("mongo_sink").await())
+                .hasStackTraceContaining("Writing records to MongoDB failed");
+    }
+
+    @Test
+    void testSinkIntoHashedPartitionedTable() throws Exception {
+        String database = "test";
+        String collection = "sink_into_hashed_sharded_collection";
+
+        // sink into sharded collection by hashed index { c: 'hashed' }.
+        Bson hashedIndex = BsonDocument.parse("{ c: 'hashed' }");
+        MongoTestUtil.createIndex(
+                mongoClient, database, collection, hashedIndex, new IndexOptions());
+        MongoTestUtil.shardCollection(mongoClient, database, collection, hashedIndex);
+
+        List<Expression> testValues =
+                Arrays.asList(
+                        row(2L, true, "ABCDEF", 12.12d, 4), row(2L, false, "ABCDEF", 12.123d, 5));
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        createPartitionedTable(
+                tEnv,
+                database,
+                collection,
+                Collections.singletonList("a"),
+                Collections.singletonList("c"));
+
+        tEnv.fromValues(testValues).executeInsert("mongo_sink").await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document expected = new Document();
+        expected.put("_id", 2L);
+        expected.put("a", 2L);
+        expected.put("b", false);
+        expected.put("c", "ABCDEF");
+        expected.put("d", 12.123d);
+        expected.put("e", 5);
+
+        assertThat(coll.find(Filters.eq("_id", 2L))).containsExactly(expected);
+    }
+
+    @Test
+    void testSinkIntoPartitionedTableAll() throws Exception {
+        String database = "test";
+        String collection = "sink_into_sharded_collection_all";
+
+        // sink into static sharded collection by unique index { b: 1, c: 1 }.
+        Bson hashedIndex = BsonDocument.parse("{ b: 1, c: 1 }");
+        MongoTestUtil.createIndex(
+                mongoClient, database, collection, hashedIndex, new IndexOptions().unique(true));
+        MongoTestUtil.shardCollection(mongoClient, database, collection, hashedIndex);
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        createPartitionedTable(
+                tEnv,
+                database,
+                collection,
+                Collections.singletonList("a"),
+                Arrays.asList("b", "c"));
+
+        tEnv.executeSql(
+                        "INSERT INTO mongo_sink PARTITION (b='true', c='ABCDEF') SELECT 3, 12.1234, 5")
+                .await();
+        tEnv.executeSql(
+                        "INSERT INTO mongo_sink PARTITION (b='true', c='ABCDEF') SELECT 3, 12.12345, 6")
+                .await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document expected = new Document();
+        expected.put("_id", 3L);
+        expected.put("a", 3L);
+        expected.put("b", true);
+        expected.put("c", "ABCDEF");
+        expected.put("d", 12.12345d);
+        expected.put("e", 6);
+
+        assertThat(coll.find(Filters.eq("_id", 3L))).containsExactly(expected);
+    }
+
+    @Test
+    void testSinkIntoPartitionedTablePart() throws Exception {
+        String database = "test";
+        String collection = "sink_into_sharded_collection_part";
+
+        // sink into static sharded collection by unique index { b: 1, c: 1 }.
+        Bson hashedIndex = BsonDocument.parse("{ c: 1, b: 1 }");
+        MongoTestUtil.createIndex(
+                mongoClient, database, collection, hashedIndex, new IndexOptions().unique(true));
+        MongoTestUtil.shardCollection(mongoClient, database, collection, hashedIndex);
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        createPartitionedTable(
+                tEnv,
+                database,
+                collection,
+                Collections.singletonList("a"),
+                Arrays.asList("c", "b"));
+
+        tEnv.executeSql(
+                        "INSERT INTO mongo_sink PARTITION (c='ABCDEFG') SELECT 4, false, 12.12345, 6")
+                .await();
+        tEnv.executeSql(
+                        "INSERT INTO mongo_sink PARTITION (c='ABCDEFG') SELECT 4, false, 12.123456, 7")
+                .await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document expected = new Document();
+        expected.put("_id", 4L);
+        expected.put("a", 4L);
+        expected.put("b", false);
+        expected.put("c", "ABCDEFG");
+        expected.put("d", 12.123456d);
+        expected.put("e", 7);
+
+        assertThat(coll.find(Filters.eq("_id", 4L))).containsExactly(expected);
+    }
+
+    private static void createPartitionedTable(
+            TableEnvironment tEnv,
+            String database,
+            String collection,
+            List<String> primaryKeys,
+            Collection<String> shareKeys) {
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE mongo_sink ("
+                                + "a BIGINT NOT NULL,\n"
+                                + "b BOOLEAN,\n"
+                                + "c STRING NOT NULL,\n"
+                                + "d DOUBLE,\n"
+                                + "e INT NOT NULL,\n"
+                                + "PRIMARY KEY (%s) NOT ENFORCED\n"
+                                + ") "
+                                + "PARTITIONED BY (%s)\n"
+                                + "WITH (%s)",
+                        formatKeys(primaryKeys),
+                        formatKeys(shareKeys),
+                        getConnectorSql(
+                                database,
+                                collection,
+                                MONGO_SHARDED_CONTAINER.getConnectionString())));
+    }
+
+    private static String formatKeys(Collection<String> fieldNames) {
+        return String.join(",", fieldNames);
+    }
+}

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPartitionedTableSinkITCase.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPartitionedTableSinkITCase.java
@@ -262,7 +262,7 @@ class MongoPartitionedTableSinkITCase {
             String database,
             String collection,
             List<String> primaryKeys,
-            Collection<String> shareKeys) {
+            Collection<String> shardKeys) {
 
         tEnv.executeSql(
                 String.format(
@@ -277,7 +277,7 @@ class MongoPartitionedTableSinkITCase {
                                 + "PARTITIONED BY (%s)\n"
                                 + "WITH (%s)",
                         formatKeys(primaryKeys),
-                        formatKeys(shareKeys),
+                        formatKeys(shardKeys),
                         getConnectorSql(
                                 database,
                                 collection,

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPrimaryKeyExtractorTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoPrimaryKeyExtractorTest.java
@@ -49,8 +49,8 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for {@link MongoKeyExtractor}. */
-public class MongoKeyExtractorTest {
+/** Tests for {@link MongoPrimaryKeyExtractor}. */
+public class MongoPrimaryKeyExtractorTest {
 
     @Test
     public void testSinglePrimaryKey() {
@@ -62,7 +62,8 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         UniqueConstraint.primaryKey("pk", Collections.singletonList("a")));
 
-        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+        Function<RowData, BsonValue> keyExtractor =
+                MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema);
 
         BsonValue key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
         assertThat(key).isEqualTo(new BsonInt64(12L));
@@ -78,7 +79,8 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         UniqueConstraint.primaryKey("pk", Collections.singletonList("_id")));
 
-        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+        Function<RowData, BsonValue> keyExtractor =
+                MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema);
 
         ObjectId objectId = new ObjectId();
         BsonValue key =
@@ -99,7 +101,7 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         UniqueConstraint.primaryKey("pk", Collections.singletonList("_id, a")));
 
-        assertThatThrownBy(() -> MongoKeyExtractor.createKeyExtractor(schema0))
+        assertThatThrownBy(() -> MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageMatching("Ambiguous keys .*");
 
@@ -111,7 +113,7 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         null);
 
-        assertThatThrownBy(() -> MongoKeyExtractor.createKeyExtractor(schema1))
+        assertThatThrownBy(() -> MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageMatching("Ambiguous keys .*");
     }
@@ -126,7 +128,8 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         null);
 
-        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+        Function<RowData, BsonValue> keyExtractor =
+                MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema);
 
         BsonValue key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
         assertThat(key).isNull();
@@ -143,7 +146,8 @@ public class MongoKeyExtractorTest {
                         Collections.emptyList(),
                         UniqueConstraint.primaryKey("pk", Arrays.asList("a", "b")));
 
-        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+        Function<RowData, BsonValue> keyExtractor =
+                MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema);
 
         BsonValue key =
                 keyExtractor.apply(
@@ -177,7 +181,8 @@ public class MongoKeyExtractorTest {
                         UniqueConstraint.primaryKey(
                                 "pk", Arrays.asList("a", "b", "c", "d", "e", "f", "g")));
 
-        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+        Function<RowData, BsonValue> keyExtractor =
+                MongoPrimaryKeyExtractor.createPrimaryKeyExtractor(schema);
 
         BsonValue key =
                 keyExtractor.apply(

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractorTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MongoShardKeysExtractor}. */
+class MongoShardKeysExtractorTest {
+
+    @Test
+    void testSingleShardKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("a")));
+
+        String[] shardKeys = new String[] {"b"};
+
+        Function<RowData, BsonDocument> shardKeysExtractor =
+                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+
+        BsonDocument actual =
+                shardKeysExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(actual).isEqualTo(new BsonDocument("b", new BsonString("ABCD")));
+    }
+
+    @Test
+    void testCompoundShardKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.STRING().notNull()),
+                                Column.physical("c", DataTypes.BIGINT())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("a")));
+
+        String[] shardKeys = new String[] {"b", "c"};
+
+        Function<RowData, BsonDocument> shardKeysExtractor =
+                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+
+        BsonDocument actual =
+                shardKeysExtractor.apply(
+                        GenericRowData.of(12L, StringData.fromString("ABCD"), 13L));
+        assertThat(actual)
+                .isEqualTo(
+                        new BsonDocument("b", new BsonString("ABCD"))
+                                .append("c", new BsonInt64(13L)));
+    }
+
+    @Test
+    void testCompoundShardKeyWithObjectId() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.STRING().notNull()),
+                                Column.physical("b", DataTypes.STRING().notNull()),
+                                Column.physical("c", DataTypes.BIGINT())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("a")));
+
+        String[] shardKeys = new String[] {"a", "b"};
+
+        Function<RowData, BsonDocument> shardKeysExtractor =
+                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+
+        ObjectId objectId = new ObjectId();
+        BsonDocument actual =
+                shardKeysExtractor.apply(
+                        GenericRowData.of(
+                                StringData.fromString(objectId.toString()),
+                                StringData.fromString("ABCD"),
+                                13L));
+        assertThat(actual)
+                .isEqualTo(
+                        new BsonDocument("a", new BsonObjectId(objectId))
+                                .append("b", new BsonString("ABCD")));
+    }
+}

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractorTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoShardKeysExtractorTest.java
@@ -54,7 +54,7 @@ class MongoShardKeysExtractorTest {
         String[] shardKeys = new String[] {"b"};
 
         Function<RowData, BsonDocument> shardKeysExtractor =
-                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+                MongoShardKeysExtractor.createShardKeysExtractor(schema, shardKeys);
 
         BsonDocument actual =
                 shardKeysExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
@@ -75,7 +75,7 @@ class MongoShardKeysExtractorTest {
         String[] shardKeys = new String[] {"b", "c"};
 
         Function<RowData, BsonDocument> shardKeysExtractor =
-                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+                MongoShardKeysExtractor.createShardKeysExtractor(schema, shardKeys);
 
         BsonDocument actual =
                 shardKeysExtractor.apply(
@@ -100,7 +100,7 @@ class MongoShardKeysExtractorTest {
         String[] shardKeys = new String[] {"a", "b"};
 
         Function<RowData, BsonDocument> shardKeysExtractor =
-                MongoShardKeysExtractor.createShardKeyExtractor(schema, shardKeys);
+                MongoShardKeysExtractor.createShardKeysExtractor(schema, shardKeys);
 
         ObjectId objectId = new ObjectId();
         BsonDocument actual =

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
@@ -126,8 +126,8 @@ public class MongoTestUtil {
     public static void shardCollection(
             MongoClient mongoClient, String databaseName, String collectionName, Bson keys) {
         MongoDatabase admin = mongoClient.getDatabase(ADMIN_DATABASE);
-        Document enableSharingCommand = new Document("enableSharding", databaseName);
-        admin.runCommand(enableSharingCommand);
+        Document enableShardingCommand = new Document("enableSharding", databaseName);
+        admin.runCommand(enableShardingCommand);
 
         Document shardCollectionCommand =
                 new Document("shardCollection", databaseName + "." + collectionName)


### PR DESCRIPTION
As [Mongo Reference](https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#upsert-on-a-sharded-collection) says:
> To use db.collection.updateOne() on a sharded collection:
>
> - If you don't specify upsert: true, you must include an exact match on the _id field or target a single shard (such as by including the shard key in the filter).
> - If you specify upsert: true, the filter must include the shard key.
>
> However, documents in a sharded collection can be missing the shard key fields. 
> To target a document that is missing the shard key, you can use the null equality match 
> in conjunction with another filter condition (such as on the _id field).

When upsert into a sharded collection, the value of the shard key needs to be added to the filter. 
For example:
```javascript
db.collection.updateOne(
    {
        _id: ObjectId('<value>'),
        shardKey0: '<value>',
        shardKey1: '<value>'
    },
    { $set: { status: "D" }},
    { upsert: true }
);
```

In Flink SQL, when creating a sink table, the shard keys need to be declared using the `PARTITIONED BY` syntax. 
The values for shard keys will be obtained from each individual record during runtime and added them into the filter.

```sql
CREATE TABLE MySinkTable (
    _id       BIGINT,
    shardKey0 STRING,
    shardKey1 STRING,
    status    STRING,
    PRIMARY KEY (_id) NOT ENFORCED
) PARTITIONED BY (shardKey0, shardKey1) WITH (
    'connector' = 'mongodb',
    'uri' = 'mongodb://user:password@127.0.0.1:27017',
    'database' = 'my_db',
    'collection' = 'users'
);

-- Insert with dynamic partition
INSERT INTO MySinkTable SELECT _id, shardKey0, shardKey1, status FROM T;

-- Insert with static partition
INSERT INTO MySinkTable PARTITION(shardKey0 = 'value0', shardKey1 = 'value1') SELECT 1, 'INIT';

-- Insert with static(shardKey0) and dynamic(shardKey1) partition
INSERT INTO MySinkTable PARTITION(shardKey0 = 'value0') SELECT 1, 'value1' 'INIT';
```