### PR TITLE
[hotfix] Remove redundant maven properties with upgrade of flink-connector-parent to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,6 @@ under the License.
 		<log4j.version>2.17.2</log4j.version>
 
 		<flink.parent.artifactId>flink-connector-mongodb-parent</flink.parent.artifactId>
-		<!-- These 2 properties should be removed together with upgrade of flink-connector-parent to 1.1.x -->
-		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
-		<surefire.module.config/>
 		<spotless.skip>false</spotless.skip>
 	</properties>
 


### PR DESCRIPTION
Remove redundant maven properties with upgrade of flink-connector-parent to 1.1.0