### PR TITLE
[FLINK-36097][Connectors/Mongodb] Add timeseries support for SampleSplitter

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
@@ -23,6 +23,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonMaxKey;
 import org.bson.BsonMinKey;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
@@ -64,6 +65,8 @@ public class MongoConstants {
     public static final BsonValue BSON_MAX_KEY = new BsonMaxKey();
 
     public static final BsonDocument ID_HINT = new BsonDocument(ID_FIELD, new BsonInt32(1));
+
+    public static final BsonString HASHED_INDEX_TYPE = new BsonString("hashed");
 
     public static final JsonWriterSettings DEFAULT_JSON_WRITER_SETTINGS =
             JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoTestUtil.java
@@ -76,8 +76,8 @@ public class MongoTestUtil {
         return DockerImageName.parse(MONGO_IMAGE_PREFIX + mongoVersion());
     }
 
-    public static String mongoVersion() {
-        return System.getProperty("mongodb.version");
+    public static MongoVersion mongoVersion() {
+        return MongoVersion.parse(System.getProperty("mongodb.version"));
     }
 
     public static void assertThatIdsAreNotWritten(MongoCollection<Document> coll, Integer... ids) {

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoVersion.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/testutils/MongoVersion.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.testutils;
+
+/** Utility of mongodb versions for MongoDB tests. */
+public class MongoVersion {
+
+    private final int major;
+
+    private final int minor;
+
+    private final int patch;
+
+    public MongoVersion(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public static MongoVersion parse(String versionString) {
+        String[] parts = versionString.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid version string: " + versionString);
+        }
+        return new MongoVersion(
+                Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+    }
+
+    public boolean isAtLeast(int major, int minor, int patch) {
+        if (this.major > major) {
+            return true;
+        } else if (this.major == major) {
+            if (this.minor > minor) {
+                return true;
+            } else if (this.minor == minor) {
+                return this.patch >= patch;
+            }
+        }
+        return false;
+    }
+
+    public String getVersionString() {
+        return major + "." + minor + "." + patch;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    @Override
+    public String toString() {
+        return getVersionString();
+    }
+}


### PR DESCRIPTION
Timeseries collections do not return a count from the `$collStats` aggregation.
In this case, it is necessary to use the `countDocuments` method to get the exact count of documents in the collection, to avoid split into a single split.