### PR TITLE
[FLINK-36075] Add pagination partitioning strategy

### DIFF
--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
@@ -65,6 +65,9 @@ public class MongoConstants {
 
     public static final BsonDocument ID_HINT = new BsonDocument(ID_FIELD, new BsonInt32(1));
 
+    public static final BsonDocument BSON_MIN_BOUNDARY = new BsonDocument(ID_FIELD, BSON_MIN_KEY);
+    public static final BsonDocument BSON_MAX_BOUNDARY = new BsonDocument(ID_FIELD, BSON_MAX_KEY);
+
     public static final JsonWriterSettings DEFAULT_JSON_WRITER_SETTINGS =
             JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/config/MongoReadOptions.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/config/MongoReadOptions.java
@@ -22,12 +22,13 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
 import org.apache.flink.connector.mongodb.source.reader.split.MongoScanSourceSplitReader;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.Objects;
 
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_FETCH_SIZE;
-import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_RECORD_SIZE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_SAMPLES;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_SIZE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_STRATEGY;
@@ -50,7 +51,7 @@ public class MongoReadOptions implements Serializable {
 
     private final int samplesPerPartition;
 
-    private final int partitionRecordSize;
+    private final @Nullable Integer partitionRecordSize;
 
     private MongoReadOptions(
             int fetchSize,
@@ -58,7 +59,7 @@ public class MongoReadOptions implements Serializable {
             PartitionStrategy partitionStrategy,
             MemorySize partitionSize,
             int samplesPerPartition,
-            int partitionRecordSize) {
+            @Nullable Integer partitionRecordSize) {
         this.fetchSize = fetchSize;
         this.noCursorTimeout = noCursorTimeout;
         this.partitionStrategy = partitionStrategy;
@@ -87,7 +88,7 @@ public class MongoReadOptions implements Serializable {
         return samplesPerPartition;
     }
 
-    public int getPartitionRecordSize() {
+    public @Nullable Integer getPartitionRecordSize() {
         return partitionRecordSize;
     }
 
@@ -123,7 +124,7 @@ public class MongoReadOptions implements Serializable {
         private PartitionStrategy partitionStrategy = SCAN_PARTITION_STRATEGY.defaultValue();
         private MemorySize partitionSize = SCAN_PARTITION_SIZE.defaultValue();
         private int samplesPerPartition = SCAN_PARTITION_SAMPLES.defaultValue();
-        private int partitionRecordSize = SCAN_PARTITION_RECORD_SIZE.defaultValue();
+        private @Nullable Integer partitionRecordSize = null;
 
         private MongoReadOptionsBuilder() {}
 
@@ -216,11 +217,8 @@ public class MongoReadOptions implements Serializable {
          * @param partitionRecordSize number of records in each partition.
          * @return this builder
          */
-        public MongoReadOptionsBuilder setPartitionRecordSize(int partitionRecordSize) {
-            checkArgument(
-                    !PartitionStrategy.PAGINATION.equals(partitionStrategy)
-                            || partitionRecordSize > 0,
-                    "The partition record size must be set in `pagination` partitioning strategy.");
+        public MongoReadOptionsBuilder setPartitionRecordSize(
+                @Nullable Integer partitionRecordSize) {
             this.partitionRecordSize = partitionRecordSize;
             return this;
         }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitter.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitter.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.util.Preconditions;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_BOUNDARY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+
+/** Mongo Splitter that splits MongoDB collection evenly by record counts. */
+@Internal
+public class MongoPaginationSplitter {
+
+    private MongoPaginationSplitter() {}
+
+    public static Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext) {
+        int partitionRecordSize = splitContext.getReadOptions().getPartitionRecordSize();
+        Preconditions.checkArgument(
+                partitionRecordSize > 0,
+                "The partition record size must be set to a positive integer.");
+
+        int numberOfPartitions =
+                (int) (Math.ceil(splitContext.getCount() / (double) partitionRecordSize));
+
+        BsonDocument lastUpperBound = null;
+        List<MongoScanSourceSplit> paginatedSplits = new ArrayList<>();
+        MongoNamespace namespace = splitContext.getMongoNamespace();
+
+        for (int splitNum = 0; splitNum < numberOfPartitions; splitNum++) {
+            List<Bson> pipeline = new ArrayList<>();
+
+            pipeline.add(Aggregates.project(Projections.include(ID_FIELD)));
+            pipeline.add(Aggregates.project(Sorts.ascending(ID_FIELD)));
+
+            // We don't have to set the upper bounds limit if we're generating the first split.
+            if (lastUpperBound != null) {
+                BsonDocument matchFilter = new BsonDocument();
+                if (lastUpperBound.containsKey(ID_FIELD)) {
+                    matchFilter.put(
+                            ID_FIELD, new BsonDocument("$gte", lastUpperBound.get(ID_FIELD)));
+                }
+                pipeline.add(Aggregates.match(matchFilter));
+            }
+            pipeline.add(Aggregates.skip(partitionRecordSize));
+            pipeline.add(Aggregates.limit(1));
+
+            BsonDocument currentUpperBound =
+                    splitContext
+                            .getMongoCollection()
+                            .aggregate(pipeline)
+                            .allowDiskUse(true)
+                            .first();
+
+            paginatedSplits.add(
+                    new MongoScanSourceSplit(
+                            String.format("%s_%d", namespace, splitNum),
+                            namespace.getDatabaseName(),
+                            namespace.getCollectionName(),
+                            lastUpperBound != null ? lastUpperBound : BSON_MIN_BOUNDARY,
+                            currentUpperBound != null ? currentUpperBound : BSON_MAX_BOUNDARY,
+                            ID_HINT));
+
+            if (currentUpperBound == null) {
+                break;
+            }
+            lastUpperBound = currentUpperBound;
+        }
+
+        return paginatedSplits;
+    }
+}

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitter.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitter.java
@@ -36,8 +36,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_BOUNDARY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
 
@@ -109,10 +109,10 @@ public class MongoSampleSplitter {
     @VisibleForTesting
     static List<MongoScanSourceSplit> createSplits(
             List<BsonDocument> samples, int samplesPerPartition, MongoNamespace namespace) {
-        samples.add(new BsonDocument(ID_FIELD, BSON_MAX_KEY));
+        samples.add(BSON_MAX_BOUNDARY);
 
         List<MongoScanSourceSplit> sourceSplits = new ArrayList<>();
-        BsonDocument partitionStart = new BsonDocument(ID_FIELD, BSON_MIN_KEY);
+        BsonDocument partitionStart = BSON_MIN_BOUNDARY;
         int splitNum = 0;
         for (int i = samplesPerPartition - 1; i < samples.size(); i += samplesPerPartition) {
             sourceSplits.add(createSplit(namespace, splitNum++, partitionStart, samples.get(i)));

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSingleSplitter.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSingleSplitter.java
@@ -20,14 +20,11 @@ package org.apache.flink.connector.mongodb.source.enumerator.splitter;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
 
-import org.bson.BsonDocument;
-
 import java.util.Collection;
 
 import static java.util.Collections.singletonList;
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_BOUNDARY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
 
 /** Mongo Splitter that splits MongoDB collection as a single split. */
@@ -42,8 +39,8 @@ public class MongoSingleSplitter {
                         splitContext.getMongoNamespace().getFullName(),
                         splitContext.getDatabaseName(),
                         splitContext.getCollectionName(),
-                        new BsonDocument(ID_FIELD, BSON_MIN_KEY),
-                        new BsonDocument(ID_FIELD, BSON_MAX_KEY),
+                        BSON_MIN_BOUNDARY,
+                        BSON_MAX_BOUNDARY,
                         ID_HINT);
 
         return singletonList(singleSplit);

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitVectorSplitter.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitVectorSplitter.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
@@ -90,7 +90,7 @@ public class MongoSplitVectorSplitter {
         }
 
         // Complete right bound: (lastKey, maxKey)
-        splitKeys.add(new BsonDocument(ID_FIELD, BSON_MAX_KEY));
+        splitKeys.add(BSON_MAX_BOUNDARY);
 
         List<MongoScanSourceSplit> sourceSplits = new ArrayList<>(splitKeys.size());
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitters.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitters.java
@@ -64,6 +64,8 @@ public class MongoSplitters {
                 return MongoSplitVectorSplitter.split(splitContext);
             case SHARDED:
                 return MongoShardedSplitter.split(splitContext);
+            case PAGINATION:
+                return MongoPaginationSplitter.split(splitContext);
             case DEFAULT:
             default:
                 return splitContext.isSharded()

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/PartitionStrategy.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/PartitionStrategy.java
@@ -55,6 +55,11 @@ public enum PartitionStrategy implements DescribedEnum {
             text(
                     "Read the chunk ranges from config.chunks collection and splits to multiple chunks. Only support sharded collections.")),
 
+    PAGINATION(
+            "pagination",
+            text(
+                    "Creating chunk records evenly by count. Each chunk will have exactly the same number of records.")),
+
     DEFAULT(
             "default",
             text(

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
@@ -103,9 +103,10 @@ public class MongoConnectorOptions {
     public static final ConfigOption<Integer> SCAN_PARTITION_RECORD_SIZE =
             ConfigOptions.key("scan.partition.record-size")
                     .intType()
-                    .defaultValue(0)
+                    .noDefaultValue()
                     .withDescription(
-                            "Specifies the number of records in each chunk. Only takes effect when `scan.partition.strategy` is `pagination`.");
+                            "Specifies the number of records in each chunk. Only takes effect when `scan.partition.strategy` is `pagination`. "
+                                    + "This option will be automatically inferred from `scan.partition.size` if absent.");
 
     public static final ConfigOption<Duration> LOOKUP_RETRY_INTERVAL =
             ConfigOptions.key("lookup.retry.interval")

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoConnectorOptions.java
@@ -75,12 +75,13 @@ public class MongoConnectorOptions {
                     .enumType(PartitionStrategy.class)
                     .defaultValue(PartitionStrategy.DEFAULT)
                     .withDescription(
-                            "Specifies the partition strategy. Available strategies are single, sample, split-vector, sharded and default."
-                                    + "The single partition strategy treats the entire collection as a single partition."
-                                    + "The sample partition strategy samples the collection and generate partitions which is fast but possibly uneven."
-                                    + "The split-vector partition strategy uses the splitVector command to generate partitions for non-sharded collections which is fast and even. The splitVector permission is required."
-                                    + "The sharded partition strategy reads config.chunks (MongoDB splits a sharded collection into chunks, and the range of the chunks are stored within the collection) as the partitions directly."
-                                    + "The sharded partition strategy is only used for sharded collection which is fast and even. Read permission of config database is required."
+                            "Specifies the partition strategy. Available strategies are single, sample, split-vector, sharded, pagination and default. "
+                                    + "The single partition strategy treats the entire collection as a single partition. "
+                                    + "The sample partition strategy samples the collection and generate partitions which is fast but possibly uneven. "
+                                    + "The split-vector partition strategy uses the splitVector command to generate partitions for non-sharded collections which is fast and even. The splitVector permission is required. "
+                                    + "The sharded partition strategy reads config.chunks (MongoDB splits a sharded collection into chunks, and the range of the chunks are stored within the collection) as the partitions directly. "
+                                    + "The sharded partition strategy is only used for sharded collection which is fast and even. Read permission of config database is required. "
+                                    + "The pagination partition strategy splits records evenly. Each chunk will have exactly the same number of records. This could be configured by `scan.partition.record-size` option. "
                                     + "The default partition strategy uses sharded strategy for sharded collections otherwise using split vector strategy.");
 
     public static final ConfigOption<MemorySize> SCAN_PARTITION_SIZE =
@@ -98,6 +99,13 @@ public class MongoConnectorOptions {
                                     + "The sample partitioner samples the collection, projects and sorts by the partition fields. "
                                     + "Then uses every 'scan.partition.samples' as the value to use to calculate the partition boundaries."
                                     + "The total number of samples taken is calculated as: samples per partition * (count of documents / number of documents per partition.");
+
+    public static final ConfigOption<Integer> SCAN_PARTITION_RECORD_SIZE =
+            ConfigOptions.key("scan.partition.record-size")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "Specifies the number of records in each chunk. Only takes effect when `scan.partition.strategy` is `pagination`.");
 
     public static final ConfigOption<Duration> LOOKUP_RETRY_INTERVAL =
             ConfigOptions.key("lookup.retry.interval")

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
@@ -179,6 +179,7 @@ public class MongoDynamicTableFactory
                 .setNoCursorTimeout(configuration.isNoCursorTimeout())
                 .setPartitionStrategy(configuration.getPartitionStrategy())
                 .setPartitionSize(configuration.getPartitionSize())
+                .setPartitionRecordSize(configuration.getPartitionRecordSize())
                 .setSamplesPerPartition(configuration.getSamplesPerPartition())
                 .build();
     }

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
@@ -91,7 +91,7 @@ public class MongoConfiguration {
         return config.get(SCAN_PARTITION_SAMPLES);
     }
 
-    public int getPartitionRecordSize() {
+    public Integer getPartitionRecordSize() {
         return config.get(SCAN_PARTITION_RECORD_SIZE);
     }
 

--- a/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
+++ b/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
@@ -38,6 +38,7 @@ import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.FIL
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.LOOKUP_RETRY_INTERVAL;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_FETCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_RECORD_SIZE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_SAMPLES;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_SIZE;
 import static org.apache.flink.connector.mongodb.table.MongoConnectorOptions.SCAN_PARTITION_STRATEGY;
@@ -88,6 +89,10 @@ public class MongoConfiguration {
 
     public int getSamplesPerPartition() {
         return config.get(SCAN_PARTITION_SAMPLES);
+    }
+
+    public int getPartitionRecordSize() {
+        return config.get(SCAN_PARTITION_RECORD_SIZE);
     }
 
     // -----------------------------------Lookup Config----------------------------------------

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.connector.mongodb.source.enumerator;
 
-import org.apache.flink.connector.mongodb.common.utils.MongoConstants;
 import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
 
 import org.bson.BsonDocument;
@@ -29,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
 import static org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumStateSerializer.INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,7 +75,7 @@ class MongoSourceEnumStateSerializerTest {
                 "db",
                 "coll",
                 new BsonDocument("_id", new BsonInt32(index)),
-                new BsonDocument("_id", MongoConstants.BSON_MAX_KEY),
+                BSON_MAX_BOUNDARY,
                 ID_HINT);
     }
 }

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitterTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitterTest.java
@@ -246,9 +246,9 @@ class MongoPaginationSplitterTest {
         for (int i = 0; i < ranges.size(); i++) {
             results.add(
                     new MongoScanSourceSplit(
-                            "test.test_" + i,
-                            "test",
-                            "test",
+                            TEST_NS.getFullName() + "_" + i,
+                            TEST_NS.getDatabaseName(),
+                            TEST_NS.getCollectionName(),
                             new BsonDocument(ID_FIELD, ranges.get(i).f0),
                             new BsonDocument(ID_FIELD, ranges.get(i).f1),
                             ID_HINT));

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitterTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoPaginationSplitterTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.testutils.MongoShardedContainers;
+import org.apache.flink.connector.mongodb.testutils.MongoTestUtil;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link MongoPaginationSplitter}. */
+class MongoPaginationSplitterTest {
+
+    @RegisterExtension
+    private static final MongoShardedContainers MONGO_SHARDED_CONTAINER =
+            MongoTestUtil.createMongoDBShardedContainers(Network.newNetwork());
+
+    private static MongoClient mongoClient;
+
+    private static final MongoNamespace TEST_NS = new MongoNamespace("test.test");
+
+    private static final int TOTAL_RECORDS_COUNT = 120;
+
+    @BeforeAll
+    static void beforeAll() {
+        mongoClient = MongoClients.create(MONGO_SHARDED_CONTAINER.getConnectionString());
+        MongoCollection<BsonDocument> coll =
+                mongoClient
+                        .getDatabase(TEST_NS.getDatabaseName())
+                        .getCollection(TEST_NS.getCollectionName())
+                        .withDocumentClass(BsonDocument.class);
+        coll.insertMany(createRecords(TOTAL_RECORDS_COUNT));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    void testMissingArgument() {
+        MongoSplitContext splitContext =
+                new MongoSplitContext(
+                        MongoReadOptions.builder().build(), mongoClient, TEST_NS, false, 0, 0, 0);
+        assertThatThrownBy(() -> new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The partition record size must be set to a positive integer.");
+    }
+
+    @Test
+    void testSplitEmptyCollection() {
+        MongoSplitContext splitContext =
+                new MongoSplitContext(
+                        MongoReadOptions.builder().setPartitionRecordSize(1).build(),
+                        mongoClient,
+                        TEST_NS,
+                        false,
+                        0,
+                        0,
+                        0);
+        assertThat(new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                .isEqualTo(Collections.emptyList());
+    }
+
+    @Test
+    void testSingleSplitPartitions() {
+        MongoSplitContext splitContext =
+                new MongoSplitContext(
+                        MongoReadOptions.builder()
+                                .setPartitionRecordSize(TOTAL_RECORDS_COUNT)
+                                .build(),
+                        mongoClient,
+                        TEST_NS,
+                        false,
+                        TOTAL_RECORDS_COUNT,
+                        0,
+                        0);
+        assertThat(new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                .isEqualTo(
+                        createReferenceSplits(
+                                Collections.singletonList(Tuple2.of(BSON_MIN_KEY, BSON_MAX_KEY))));
+    }
+
+    @Test
+    void testLargerSizedPartitions() {
+        MongoSplitContext splitContext =
+                new MongoSplitContext(
+                        MongoReadOptions.builder().setPartitionRecordSize(15).build(),
+                        mongoClient,
+                        TEST_NS,
+                        false,
+                        TOTAL_RECORDS_COUNT,
+                        0,
+                        0);
+        assertThat(new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                .isEqualTo(
+                        createReferenceSplits(
+                                Arrays.asList(
+                                        Tuple2.of(BSON_MIN_KEY, new BsonInt64(15)),
+                                        Tuple2.of(new BsonInt64(15), new BsonInt64(30)),
+                                        Tuple2.of(new BsonInt64(30), new BsonInt64(45)),
+                                        Tuple2.of(new BsonInt64(45), new BsonInt64(60)),
+                                        Tuple2.of(new BsonInt64(60), new BsonInt64(75)),
+                                        Tuple2.of(new BsonInt64(75), new BsonInt64(90)),
+                                        Tuple2.of(new BsonInt64(90), new BsonInt64(105)),
+                                        Tuple2.of(new BsonInt64(105), BSON_MAX_KEY))));
+    }
+
+    @Test
+    void testOffByOnePartitions() {
+        {
+            MongoSplitContext splitContext =
+                    new MongoSplitContext(
+                            MongoReadOptions.builder()
+                                    .setPartitionRecordSize(TOTAL_RECORDS_COUNT - 1)
+                                    .build(),
+                            mongoClient,
+                            TEST_NS,
+                            false,
+                            TOTAL_RECORDS_COUNT,
+                            0,
+                            0);
+            assertThat(new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                    .isEqualTo(
+                            createReferenceSplits(
+                                    Arrays.asList(
+                                            Tuple2.of(
+                                                    BSON_MIN_KEY,
+                                                    new BsonInt64(TOTAL_RECORDS_COUNT - 1)),
+                                            Tuple2.of(
+                                                    new BsonInt64(TOTAL_RECORDS_COUNT - 1),
+                                                    BSON_MAX_KEY))));
+        }
+
+        {
+            MongoSplitContext splitContext =
+                    new MongoSplitContext(
+                            MongoReadOptions.builder()
+                                    .setPartitionRecordSize(TOTAL_RECORDS_COUNT)
+                                    .build(),
+                            mongoClient,
+                            TEST_NS,
+                            false,
+                            TOTAL_RECORDS_COUNT,
+                            0,
+                            0);
+            assertThat(new ArrayList<>(MongoPaginationSplitter.split(splitContext)))
+                    .isEqualTo(
+                            createReferenceSplits(
+                                    Collections.singletonList(
+                                            Tuple2.of(BSON_MIN_KEY, BSON_MAX_KEY))));
+        }
+    }
+
+    private static List<BsonDocument> createRecords(int samplesCount) {
+        return IntStream.range(0, samplesCount)
+                .mapToObj(
+                        idx ->
+                                new BsonDocument("_id", new BsonInt64(idx))
+                                        .append(
+                                                "str",
+                                                new BsonString(String.format("Record #%d", idx))))
+                .collect(Collectors.toList());
+    }
+
+    private static List<MongoScanSourceSplit> createReferenceSplits(
+            List<Tuple2<BsonValue, BsonValue>> ranges) {
+
+        List<MongoScanSourceSplit> results = new ArrayList<>();
+        for (int i = 0; i < ranges.size(); i++) {
+            results.add(
+                    new MongoScanSourceSplit(
+                            "test.test_" + i,
+                            "test",
+                            "test",
+                            new BsonDocument(ID_FIELD, ranges.get(i).f0),
+                            new BsonDocument(ID_FIELD, ranges.get(i).f1),
+                            ID_HINT));
+        }
+        return results;
+    }
+}

--- a/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitterTest.java
+++ b/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitterTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
-import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_BOUNDARY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_BOUNDARY;
 import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,8 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MongoSampleSplitterTest {
 
     private static final MongoNamespace TEST_NS = new MongoNamespace("test.test");
-    private static final BsonDocument MIN = new BsonDocument(ID_FIELD, BSON_MIN_KEY);
-    private static final BsonDocument MAX = new BsonDocument(ID_FIELD, BSON_MAX_KEY);
 
     @Test
     void testSplitEmptyCollection() {
@@ -124,7 +122,7 @@ class MongoSampleSplitterTest {
         assertThat(splits.get(0))
                 .satisfies(
                         split -> {
-                            assertThat(split.getMin()).isEqualTo(MIN);
+                            assertThat(split.getMin()).isEqualTo(BSON_MIN_BOUNDARY);
                             assertThat(split.getMax()).isEqualTo(samples.get(1));
                         });
         assertThat(splits.get(1))
@@ -137,7 +135,7 @@ class MongoSampleSplitterTest {
                 .satisfies(
                         split -> {
                             assertThat(split.getMin()).isEqualTo(samples.get(3));
-                            assertThat(split.getMax()).isEqualTo(MAX);
+                            assertThat(split.getMax()).isEqualTo(BSON_MAX_BOUNDARY);
                         });
     }
 
@@ -151,7 +149,7 @@ class MongoSampleSplitterTest {
 
     private static void assertSingleSplit(List<MongoScanSourceSplit> splits) {
         assertThat(splits.size()).isEqualTo(1);
-        assertThat(splits.get(0).getMin()).isEqualTo(MIN);
-        assertThat(splits.get(0).getMax()).isEqualTo(MAX);
+        assertThat(splits.get(0).getMin()).isEqualTo(BSON_MIN_BOUNDARY);
+        assertThat(splits.get(0).getMax()).isEqualTo(BSON_MAX_BOUNDARY);
     }
 }


### PR DESCRIPTION
This closes FLINK-36075 by:

* Adding new enum value `pagination` for `scan.partition.strategy` option
* Adding `scan.partition.record-size` option to specify the pagination size for each split

Marked it as a draft since more discussion is needed over the API design.