### PR TITLE
[FLINK-35139][Connectors/MongoDB] Drop support for Flink 1.18 and update development version to 2.0-SNAPSHOT

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,19 +31,6 @@ jobs:
         mongodb: [ mongodb4, mongodb5, mongodb6, mongodb7 ]
         flink: [ 1.19-SNAPSHOT, 1.20-SNAPSHOT ]
         jdk: [ '8, 11, 17, 21' ]
-        include:
-          - mongodb: mongodb4
-            flink: 1.18-SNAPSHOT
-            jdk: '8, 11, 17'
-          - mongodb: mongodb5
-            flink: 1.18-SNAPSHOT
-            jdk: '8, 11, 17'
-          - mongodb: mongodb6
-            flink: 1.18-SNAPSHOT
-            jdk: '8, 11, 17'
-          - mongodb: mongodb7
-            flink: 1.18-SNAPSHOT
-            jdk: '8, 11, 17'
 
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,10 +30,6 @@ jobs:
     strategy:
       matrix:
         flink_branches: [ {
-          flink: 1.18-SNAPSHOT,
-          jdk: '8, 11, 17',
-          branch: main
-        }, {
           flink: 1.19-SNAPSHOT,
           jdk: '8, 11, 17, 21',
           branch: main
@@ -42,13 +38,13 @@ jobs:
           jdk: '8, 11, 17, 21',
           branch: main
         },{
-          flink: 1.18.1,
-          jdk: '8, 11, 17',
-          branch: v1.2
-        }, {
           flink: 1.19.1,
           jdk: '8, 11, 17, 21',
           branch: v1.2
+        }, {
+          flink: 1.20.0,
+          jdk: '8, 11, 17, 21',
+          branch: main
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/docs/data/mongodb.yml
+++ b/docs/data/mongodb.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-version: 1.3.0-SNAPSHOT
+version: 2.0-SNAPSHOT
 variants:
   - maven: flink-connector-mongodb
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-mongodb/$full_version/flink-sql-connector-mongodb-$full_version.jar

--- a/flink-connector-mongodb-e2e-tests/pom.xml
+++ b/flink-connector-mongodb-e2e-tests/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connector-mongodb-parent</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.3-SNAPSHOT</version>
+		<version>2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-mongodb-e2e-tests</artifactId>

--- a/flink-connector-mongodb/pom.xml
+++ b/flink-connector-mongodb/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connector-mongodb-parent</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.3-SNAPSHOT</version>
+		<version>2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-mongodb</artifactId>

--- a/flink-sql-connector-mongodb/pom.xml
+++ b/flink-sql-connector-mongodb/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connector-mongodb-parent</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.3-SNAPSHOT</version>
+		<version>2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-mongodb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<mongodb7.version>7.0.12</mongodb7.version>
 		<mongodb.version>${mongodb4.version}</mongodb.version>
 
-		<flink.version>1.18.0</flink.version>
+		<flink.version>1.20.0</flink.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala-library.version>2.12.7</scala-library.version>
 		<junit5.version>5.8.1</junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-mongodb-parent</artifactId>
-	<version>1.3-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 
 	<name>Flink : Connectors : MongoDB Parent</name>
 	<packaging>pom</packaging>


### PR DESCRIPTION
Drop support for Flink 1.18 and update development version to 2.0-SNAPSHOT