### PR TITLE
[FLINK-39643][docs] Sync MongoDB connector docs for sink options and PAGINATION strategy

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/mongodb.md
+++ b/docs/content.zh/docs/connectors/datastream/mongodb.md
@@ -38,7 +38,9 @@ Flink 提供了 [MongoDB](https://www.mongodb.com/) 连接器使用至少一次�
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.mongodb.source.MongoSource;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
 import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -130,6 +132,7 @@ Flink 的 MongoDB Source 可以通过 `MongoSource.<OutputType>builder()` 构造
   仅适用于未分片集合，需要 splitVector 权限。
 - `SHARDED`：从 `config.chunks` 集合中直接读取分片集合的分片边界作为分区，不需要额外计算，快速且均匀。
   仅适用于已经分片的集合，需要 config 数据库的读取权限。
+- `PAGINATION`：按数量均匀创建分区。每个分区将具有完全相同的记录数。
 - `DEFAULT`：对分片集合使用 `SHARDED` 策略，对未分片集合使用 `SPLIT_VECTOR` 策略。
 
 ## MongoDB Sink
@@ -165,7 +168,7 @@ stream.sinkTo(sink);
 {{< /tabs >}}
 
 ### 配置项
-Flink 的 MongoDB Source 可以通过 `MongoSink.<InputType>builder()` 构造器构建。
+Flink 的 MongoDB Sink 可以通过 `MongoSink.<InputType>builder()` 构造器构建。
 
 1. __setUri(String uri)__
     * 必须。
@@ -188,7 +191,13 @@ Flink 的 MongoDB Source 可以通过 `MongoSink.<InputType>builder()` 构造器
 7. _setDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee)_
     * 可选。默认值：`DeliveryGuarantee.AT_LEAST_ONCE`.
     * 设置投递保证。 仅一次（EXACTLY_ONCE）的投递保证暂不支持。
-8. __setSerializationSchema(MongoSerializationSchema<InputType> serializationSchema)__
+8. _setOrderedWrites(boolean ordered)_
+    * 可选。默认值：`true`。
+    * 设置 MongoDB 驱动的有序写入选项。
+9. _setBypassDocumentValidation(boolean bypassDocumentValidation)_
+    * 可选。默认值：`false`。
+    * 设置 MongoDB 驱动的跳过文档校验选项。
+10. __setSerializationSchema(MongoSerializationSchema<InputType> serializationSchema)__
     * 必须。
     * 设置 `MongoSerializationSchema` 将输入类型转换为 MongoDB
       [WriteModel](https://www.mongodb.com/docs/drivers/java/sync/current/usage-examples/bulkWrite/)。

--- a/docs/content.zh/docs/connectors/table/mongodb.md
+++ b/docs/content.zh/docs/connectors/table/mongodb.md
@@ -38,8 +38,7 @@ MongoDB 连接器提供了从 MongoDB 中读取和写入数据的能力。
 
 依赖
 ------------
-In order to use the MongoDB connector the following dependencies are required for both projects 
-using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
+使用 MongoDB 连接器需要以下依赖。这些依赖适用于使用构建工具（如 Maven 或 SBT）的项目和带有 SQL JAR 包的 SQL 客户端。
 
 {{< sql_connector_download_table "mongodb" >}}
 
@@ -288,9 +287,25 @@ ON myTopic.key = MyUserTable._id;
       <td><h5>sink.delivery-guarantee</h5></td>
       <td>可选</td>
       <td>否</td>
-      <td style="word-wrap: break-word;">at-lease-once</td>
+      <td style="word-wrap: break-word;">at-least-once</td>
       <td><p>Enum</p>可选值: none, at-least-once</td>
       <td>设置投递保证。仅一次（exactly-once）的投递保证暂不支持。</td>
+    </tr>
+    <tr>
+      <td><h5>sink.ordered-writes</h5></td>
+      <td>可选</td>
+      <td>否</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>设置 MongoDB 驱动的有序写入选项。默认为 true，表示按顺序写入。</td>
+    </tr>
+    <tr>
+      <td><h5>sink.bypass-document-validation</h5></td>
+      <td>可选</td>
+      <td>否</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>设置 MongoDB 驱动的跳过文档校验选项。默认为 false，表示对文档进行校验。</td>
     </tr> 
     </tbody>
 </table>
@@ -331,6 +346,7 @@ MongoDB 连接器通过将 DDL 声明的主键进行组合，来生成文档的�
   仅适用于未分片集合，需要 splitVector 权限。
 - `sharded`: 从 `config.chunks` 集合中直接读取分片集合的分片边界作为分区，不需要额外计算，快速且均匀。
   仅适用于已经分片的集合，需要 config 数据库的读取权限。
+- `pagination`: 按数量均匀创建分区。每个分区将具有完全相同的记录数。
 - `default`: 对分片集合使用 `sharded` 策略，对未分片集合使用 `split-vector` 策略。
 
 ### Lookup Cache

--- a/docs/content/docs/connectors/datastream/mongodb.md
+++ b/docs/content/docs/connectors/datastream/mongodb.md
@@ -40,7 +40,9 @@ The example below shows how to configure and create a source:
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.mongodb.source.MongoSource;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
 import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -144,6 +146,8 @@ The following partition strategies are provided:
   range of the chunks are stored within the collection) as the partitions directly. The
   sharded strategy only used for sharded collection which is fast and even. Read permission
   of config database is required.
+- `PAGINATION`: creates chunk records evenly by count. Each chunk will have exactly the same
+  number of records.
 - `DEFAULT`: uses sharded strategy for sharded collections otherwise using split vector
   strategy.
 
@@ -207,10 +211,10 @@ Flink's MongoDB sink is created by using the static builder `MongoSink.<InputTyp
 8. _setOrderedWrites(boolean ordered)_
     * Optional. Default: `true`
     * Defines MongoDB driver option to perform ordered writes.
-8. _setBypassDocumentValidation(boolean bypassDocumentValidation)_
+9. _setBypassDocumentValidation(boolean bypassDocumentValidation)_
     * Optional. Default: `false`
     * Defines MongoDB driver option to bypass document validation. 
-9. __setSerializationSchema(MongoSerializationSchema<InputType> serializationSchema)__
+10. __setSerializationSchema(MongoSerializationSchema<InputType> serializationSchema)__
     * Required.
     * A `MongoSerializationSchema` is required for parsing input record to MongoDB 
       [WriteModel](https://www.mongodb.com/docs/drivers/java/sync/current/usage-examples/bulkWrite/).

--- a/docs/content/docs/connectors/table/mongodb.md
+++ b/docs/content/docs/connectors/table/mongodb.md
@@ -294,7 +294,7 @@ Connector Options
       <td><h5>sink.delivery-guarantee</h5></td>
       <td>optional</td>
       <td>no</td>
-      <td style="word-wrap: break-word;">at-lease-once</td>
+      <td style="word-wrap: break-word;">at-least-once</td>
       <td><p>Enum</p>Possible values: none, at-least-once</td>
       <td>Optional delivery guarantee when committing. The exactly-once guarantee is not supported yet.</td>
     </tr>
@@ -366,6 +366,8 @@ feature for MongoDB collection. The following partition strategies are provided:
   range of the chunks are stored within the collection) as the partitions directly. The
   sharded strategy only used for sharded collection which is fast and even. Read permission
   of config database is required.
+- `pagination`: creates chunk records evenly by count. Each chunk will have exactly the same
+  number of records.
 - `default`: uses sharded strategy for sharded collections otherwise using split vector
   strategy.
 


### PR DESCRIPTION
## What is the purpose of the change

Sync the MongoDB connector documentation with the latest source/sink capabilities, fix a couple of long-standing typos, and align the Chinese and English docs.

Tracked by [FLINK-39643](https://issues.apache.org/jira/browse/FLINK-39643).

## Brief change log

- Document the `PAGINATION` partition strategy in the DataStream docs (zh + en).
- Document the `setOrderedWrites` and `setBypassDocumentValidation` sink builder options in the DataStream docs and renumber the subsequent items (zh + en).
- Fix `MongoDB Source` -> `MongoDB Sink` typo in the zh DataStream doc.
- Fix `at-lease-once` -> `at-least-once` typo in the en Table doc.

## Verifying this change

This change is a trivial rework / documentation update without any test coverage.

- Reviewed the rendered docs locally for both `docs/content` and `docs/content.zh`.
- Cross-checked the documented sink builder options against `MongoSinkBuilder` and `MongoWriteOptions`.
- Cross-checked the documented partition strategies against `PartitionStrategy` (`SAMPLE`, `SPLIT_VECTOR`, `SHARDED`, `PAGINATION`, `SINGLE`, `DEFAULT`).

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API are classes annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / **changed docs**)